### PR TITLE
Release 0.4.0: iOS keyboard fix, unified messaging, deps CVE, docs polish

### DIFF
--- a/.github/dockerhub/README.md
+++ b/.github/dockerhub/README.md
@@ -199,10 +199,11 @@ docker run -d \
 ## Documentation
 
 - [Project repository](https://github.com/orenlab/pytmbot)
-- [Runtime documentation](https://github.com/orenlab/pytmbot/blob/master/docs/docker.md)
-- [Settings reference](https://github.com/orenlab/pytmbot/blob/master/docs/settings.md)
-- [CLI reference](https://github.com/orenlab/pytmbot/blob/master/docs/bot_cli_args.md)
-- [Release policy](https://github.com/orenlab/pytmbot/blob/master/docs/release_policy.md)
+- [Documentation home](https://orenlab.github.io/pytmbot/)
+- [Runtime documentation](https://orenlab.github.io/pytmbot/docker/)
+- [Settings reference](https://orenlab.github.io/pytmbot/settings/)
+- [CLI reference](https://orenlab.github.io/pytmbot/bot_cli_args/)
+- [Release policy](https://orenlab.github.io/pytmbot/release_policy/)
 
 ## License
 

--- a/.github/dockerhub/README.md
+++ b/.github/dockerhub/README.md
@@ -23,8 +23,8 @@ Stable public tags:
 
 | Tag      | Description                   |
 |----------|-------------------------------|
-| `0.3.3`  | Exact immutable release image |
-| `0.3`    | Current supported stable line |
+| `0.4.0`  | Exact immutable release image |
+| `0.4`    | Current supported stable line |
 | `stable` | Stable channel alias          |
 | `latest` | Alias of `stable`             |
 
@@ -32,11 +32,11 @@ Additional tags:
 
 | Tag                 | Description                                   |
 |---------------------|-----------------------------------------------|
-| `0.3-rYYYYMMDD`     | Dated weekly rebuild of the stable line       |
+| `0.4-rYYYYMMDD`     | Dated weekly rebuild of the stable line       |
 | `edge-<branch>`     | Development image for a feature or fix branch |
 | `edge-sha-<gitsha>` | Development image pinned to a branch commit   |
 
-Recommended: use `0.3.3` for reproducible production rollouts, `stable` for the supported channel. Do not use `edge-*`
+Recommended: use `0.4.0` for reproducible production rollouts, `stable` for the supported channel. Do not use `edge-*`
 tags in production.
 
 ## Image Features
@@ -102,7 +102,7 @@ docker run -d \
   orenlab/pytmbot:stable --mode prod
 ```
 
-For pinned rollouts, replace `stable` with `0.3.3`. To enforce Docker socket availability on startup, add
+For pinned rollouts, replace `stable` with `0.4.0`. To enforce Docker socket availability on startup, add
 `-e STRICT_DOCKER_ACCESS=True`.
 
 ## Docker Compose Example
@@ -191,8 +191,8 @@ docker run -d \
 
 ## Upgrade Policy
 
-- Exact release tags (`0.3.3`) are immutable.
-- Floating tags (`0.3`, `stable`, `latest`) can move forward.
+- Exact release tags (`0.4.0`) are immutable.
+- Floating tags (`0.4`, `stable`, `latest`) can move forward.
 - Weekly rebuilds refresh the Ubuntu base image and installed OS packages.
 - Python dependency updates require a committed `uv.lock` change and a new release.
 

--- a/.github/workflows/rebuild_supported_tags.yml
+++ b/.github/workflows/rebuild_supported_tags.yml
@@ -10,7 +10,7 @@ permissions:
 
 env:
   DOCKER_IMAGE: orenlab/pytmbot
-  STABLE_RELEASE_LINE: "0.3"
+  STABLE_RELEASE_LINE: "0.4"
 
 jobs:
   docker:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## [0.4.0] — Unreleased
+## [0.4.0] — 20260624
+
+Modest stable release focused on Telegram iOS keyboard reliability, unified outbound messaging, dependency maintenance, and documentation polish.
 
 ### Fixed
 
@@ -12,11 +14,11 @@
 
 ### Changed
 
-- Added `0.4.0.dev0` to the supported `config_version` compatibility matrix.
-- Bumped the development version to `0.4.0-dev`.
-- Refreshed direct dependencies and regenerated `uv.lock`: `fastapi` (`>=0.138.0`), `pydantic-settings` (`>=2.14.2`), `pyotp` (`>=2.10.0`), and dev `pytest` (`>=9.1.1`).
+- Added `0.4.0` to the supported `config_version` compatibility matrix.
 - Unified Telegram outbound messaging through `send_bot_message()` / `send_*_message()` helpers so text-only replies, plugin screens, auth flows, and post-delete navigation consistently preserve the active reply keyboard.
 - Post-delete navigation now accepts a section keyboard (`main`, `server`, or `docker`); Docker log exports restore the Docker menu after auto-delete.
+- Refreshed direct dependencies and regenerated `uv.lock`: `fastapi` (`>=0.138.0`), `pydantic-settings` (`>=2.14.2`), `pyotp` (`>=2.10.0`), and dev `pytest` (`>=9.1.1`).
+- Updated release metadata, sample configuration, documentation, Docker tag references, and user-facing documentation links to `0.4.0`.
 
 ## [0.3.3] — 20260612
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.4.0] — Unreleased
+
+### Fixed
+
+- Fixed the reply keyboard disappearing on Telegram iOS during normal bot use by enabling persistent section keyboards and re-attaching the correct navigation keyboard on text-only replies, middleware warnings, and post-delete navigation.
+
+### Changed
+
+- Added `0.4.0.dev0` to the supported `config_version` compatibility matrix.
+- Bumped the development version to `0.4.0-dev`.
+- Refreshed direct dependencies and regenerated `uv.lock`: `fastapi` (`>=0.137.1`), `pyotp` (`>=2.10.0`), and dev `pytest` (`>=9.1.0`).
+
 ## [0.3.3] — 20260612
 
 Patch release focused exclusively on dependency maintenance.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 - Added `0.4.0.dev0` to the supported `config_version` compatibility matrix.
 - Bumped the development version to `0.4.0-dev`.
 - Refreshed direct dependencies and regenerated `uv.lock`: `fastapi` (`>=0.137.1`), `pyotp` (`>=2.10.0`), and dev `pytest` (`>=9.1.0`).
+- Unified Telegram outbound messaging through `send_bot_message()` / `send_*_message()` helpers so text-only replies, plugin screens, auth flows, and post-delete navigation consistently preserve the active reply keyboard.
+- Post-delete navigation now accepts a section keyboard (`main`, `server`, or `docker`); Docker log exports restore the Docker menu after auto-delete.
 
 ## [0.3.3] — 20260612
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,15 @@
 
 - Fixed the reply keyboard disappearing on Telegram iOS during normal bot use by enabling persistent section keyboards and re-attaching the correct navigation keyboard on text-only replies, middleware warnings, and post-delete navigation.
 
+### Security
+
+- Bumped `pydantic-settings` to `>=2.14.2` and refreshed transitive dependencies in `uv.lock` to address symlink traversal in `NestedSecretsSettingsSource`.
+
 ### Changed
 
 - Added `0.4.0.dev0` to the supported `config_version` compatibility matrix.
 - Bumped the development version to `0.4.0-dev`.
-- Refreshed direct dependencies and regenerated `uv.lock`: `fastapi` (`>=0.137.1`), `pyotp` (`>=2.10.0`), and dev `pytest` (`>=9.1.0`).
+- Refreshed direct dependencies and regenerated `uv.lock`: `fastapi` (`>=0.138.0`), `pydantic-settings` (`>=2.14.2`), `pyotp` (`>=2.10.0`), and dev `pytest` (`>=9.1.1`).
 - Unified Telegram outbound messaging through `send_bot_message()` / `send_*_message()` helpers so text-only replies, plugin screens, auth flows, and post-delete navigation consistently preserve the active reply keyboard.
 - Post-delete navigation now accepts a section keyboard (`main`, `server`, or `docker`); Docker log exports restore the Docker menu after auto-delete.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@
 # syntax=docker/dockerfile:1.7
 
 ARG UBUNTU_IMAGE=24.04
-ARG UV_IMAGE=ghcr.io/astral-sh/uv:0.11.4
+ARG UV_IMAGE=ghcr.io/astral-sh/uv:0.11.24
 ARG COMPILE_BYTECODE=1
 
 ########################################################################################################################

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ and [docker-py](https://github.com/docker/docker-py).
 
 ### 1. Prepare your config
 
-Create `/etc/pytmbot/pytmbot.yaml` following the [settings guide](docs/settings.md).
+Create `/etc/pytmbot/pytmbot.yaml` following the [settings guide](https://orenlab.github.io/pytmbot/settings/).
 
 ### 2. Deploy with Docker Compose
 
@@ -77,7 +77,7 @@ docker compose up -d
 ```
 
 For a hardened production setup with resource limits, tmpfs, network isolation, and health checks —
-see [docs/docker.md](docs/docker.md).
+see the [Docker runtime guide](https://orenlab.github.io/pytmbot/docker/).
 
 ---
 
@@ -122,7 +122,7 @@ Two plugins are included out of the box:
 
 **Outline VPN Plugin** — monitor your [Outline VPN](https://getoutline.org/) server from Telegram.
 
-See [docs/plugins.md](docs/plugins.md) for the plugin API and configuration reference.
+See the [plugins guide](https://orenlab.github.io/pytmbot/plugins/) for the plugin API and configuration reference.
 
 ---
 
@@ -140,7 +140,7 @@ See [docs/plugins.md](docs/plugins.md) for the plugin API and configuration refe
 **Polling** — simplest deployment; no HTTPS or public endpoint required.
 
 **Webhook** — lower latency; requires a public hostname for Telegram `setWebhook`.
-See [docs/webhook.md](docs/webhook.md).
+See the [webhook guide](https://orenlab.github.io/pytmbot/webhook/).
 
 ---
 
@@ -150,26 +150,26 @@ Full docs: [orenlab.github.io/pytmbot](https://orenlab.github.io/pytmbot/)
 
 | Guide                                        | Description                           |
 |----------------------------------------------|---------------------------------------|
-| [Installation](docs/installation.md)         | Step-by-step setup                    |
-| [Docker](docs/docker.md)                     | Docker-specific deployment            |
-| [Settings](docs/settings.md)                 | `pytmbot.yaml` reference              |
-| [Commands](docs/commands.md)                 | All bot commands                      |
-| [Webhook mode](docs/webhook.md)              | Webhook setup and proxy config        |
-| [Security](docs/security.md)                 | Hardening and threat model            |
-| [Access control & 2FA](docs/auth_control.md) | Allowlists and TOTP                   |
-| [Health system](docs/health.md)              | Startup and runtime checks            |
-| [Plugins](docs/plugins.md)                   | Plugin API and bundled plugins        |
-| [CLI arguments](docs/bot_cli_args.md)        | `--log-level`, `--health_check`, etc. |
-| [Architecture](docs/architecture.md)         | Internal design overview              |
-| [Development](docs/development.md)           | Contributing and local setup          |
-| [Roadmap](docs/roadmap.md)                   | Planned features                      |
-| [Debugging](docs/debug.md)                   | Logging and troubleshooting           |
+| [Installation](https://orenlab.github.io/pytmbot/installation/)         | Step-by-step setup                    |
+| [Docker](https://orenlab.github.io/pytmbot/docker/)                     | Docker-specific deployment            |
+| [Settings](https://orenlab.github.io/pytmbot/settings/)                 | `pytmbot.yaml` reference              |
+| [Commands](https://orenlab.github.io/pytmbot/commands/)                 | All bot commands                      |
+| [Webhook mode](https://orenlab.github.io/pytmbot/webhook/)              | Webhook setup and proxy config        |
+| [Security](https://orenlab.github.io/pytmbot/security/)                 | Hardening and threat model            |
+| [Access control & 2FA](https://orenlab.github.io/pytmbot/auth_control/) | Allowlists and TOTP                   |
+| [Health system](https://orenlab.github.io/pytmbot/health/)              | Startup and runtime checks            |
+| [Plugins](https://orenlab.github.io/pytmbot/plugins/)                   | Plugin API and bundled plugins        |
+| [CLI arguments](https://orenlab.github.io/pytmbot/bot_cli_args/)        | `--log-level`, `--health_check`, etc. |
+| [Architecture](https://orenlab.github.io/pytmbot/architecture/)         | Internal design overview              |
+| [Development](https://orenlab.github.io/pytmbot/development/)           | Contributing and local setup          |
+| [Roadmap](https://orenlab.github.io/pytmbot/roadmap/)                   | Planned features                      |
+| [Debugging](https://orenlab.github.io/pytmbot/debug/)                   | Logging and troubleshooting           |
 
 ---
 
 ## Contributing
 
-Bug reports, feature requests, and pull requests are welcome. Please read [docs/development.md](docs/development.md)
+Bug reports, feature requests, and pull requests are welcome. Please read the [development guide](https://orenlab.github.io/pytmbot/development/)
 before submitting a PR.
 
 ---

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,8 +6,8 @@ The following versions of pyTMbot are actively supported:
 
 | Version | Supported          | End of Life |
 |---------|--------------------|-------------|
-| 0.3.3   | :white_check_mark: | TBD         |
-| < 0.3.0 | :x:                | 2026-02-18  |
+| 0.4.0   | :white_check_mark: | TBD         |
+| < 0.4.0 | :x:                | 2026-06-24  |
 
 ## Reporting a Vulnerability
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -21,7 +21,7 @@ Instead, please report them privately by:
 To assist us in understanding and addressing the issue, please include the following information:
 
 1. **Description of the vulnerability:** Clearly describe the issue, including steps to reproduce if possible.
-2. **Debug Log:** Attach the [debug log](docs/debug.md) of the bot's activity, which will help us diagnose the problem.
+2. **Debug Log:** Attach the [debug log](https://orenlab.github.io/pytmbot/debug/) of the bot's activity, which will help us diagnose the problem.
    Ensure that no sensitive data (such as tokens or personal information) is included in the log.
 
 ## Our Commitment

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -99,6 +99,12 @@ The bot also exposes callback-driven flows that are not slash commands:
 - Those views are entered through the reply keyboard or inline navigation after `/server` or `Quick view`.
 - Command access is still gated by allowlists, middleware, and optional 2FA.
 
+## Reply Keyboard Behavior
+
+- Section menus (`main`, `server`, `docker`, plugins) use persistent reply keyboards so Telegram clients (notably iOS) keep the menu visible while you browse inline screens.
+- Text-only bot replies re-attach the matching section keyboard automatically.
+- Ephemeral messages removed by auto-delete (for example `/getmyid`, QR setup, exported Docker logs) send a short follow-up that restores the appropriate menu keyboard.
+
 ## Related Docs
 
 - [auth_control.md](auth_control.md)

--- a/docs/development.md
+++ b/docs/development.md
@@ -120,6 +120,7 @@ Operational notes:
 ## Documentation Maintenance Rules
 
 - `pytmbot.yaml.sample` is the canonical sample config.
+- User-facing files outside `docs/` (`README.md`, `SECURITY.md`, Docker Hub README, bot templates) must link to `https://orenlab.github.io/pytmbot/`, not repository `docs/*.md` paths.
 - Docs should point to current code paths, not historical behavior.
 - Docs site must pass `zensical build --strict`.
 - If codeclone flags dynamic false positives, use the supported inline suppression syntax rather than broad ignores.

--- a/docs/development.md
+++ b/docs/development.md
@@ -96,6 +96,8 @@ Current GitHub Actions workflows cover:
 Starting with the `0.3.0` release line:
 
 - all versions older than `0.3.0` are end-of-life
+- the `0.3.x` line is end-of-life as of `0.4.0`
+- only the current `0.4` stable line receives weekly rebuilds
 - exact release tags stay immutable
 - floating stable tags are refreshed by the weekly rebuild workflow
 - development tags are separate from the public stable contract

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -20,14 +20,14 @@ Published image:
 
 Stable public tags:
 
-- `0.3.3` for an exact release image
-- `0.3` for the current supported stable line
+- `0.4.0` for an exact release image
+- `0.4` for the current supported stable line
 - `stable` as the stable-channel alias
 - `latest` as an alias of `stable`
 
 Additional tags:
 
-- `0.3-rYYYYMMDD` for dated weekly stable-line rebuilds
+- `0.4-rYYYYMMDD` for dated weekly stable-line rebuilds
 - `edge-<branch>` and `edge-sha-<gitsha>` for development images from `feat/*` and `fix/*` branches
 
 See [release_policy.md](release_policy.md) for the full contract.

--- a/docs/release_policy.md
+++ b/docs/release_policy.md
@@ -12,38 +12,39 @@ Source of truth:
 ## Support Scope
 
 - Starting with `0.3.0`, all versions older than `0.3.0` are end-of-life.
-- Only the current `0.3` stable line receives rebuilds and security refreshes.
+- Only the current `0.4` stable line receives rebuilds and security refreshes.
+- The `0.3.x` line is end-of-life as of `0.4.0`.
 - No compatibility or support guarantees are provided for pre-`0.3.0` images.
 
 ## Public Stable Tags
 
 Public stable tags published to `orenlab/pytmbot`:
 
-- `0.3.3`: exact release image, immutable
-- `0.3`: current supported stable line, mutable
+- `0.4.0`: exact release image, immutable
+- `0.4`: current supported stable line, mutable
 - `stable`: alias for the current supported stable line, mutable
 - `latest`: alias for `stable`, mutable
-- `0.3-rYYYYMMDD`: dated stable-line rebuild, mutable only by date creation
+- `0.4-rYYYYMMDD`: dated stable-line rebuild, mutable only by date creation
 
 ## Tag Semantics
 
-- Use `0.3.3` when you need a reproducible artifact tied to a specific release.
-- Use `0.3` when you want the current supported stable line with weekly OS/base-image refreshes.
+- Use `0.4.0` when you need a reproducible artifact tied to a specific release.
+- Use `0.4` when you want the current supported stable line with weekly OS/base-image refreshes.
 - Use `stable` when you want the supported stable channel without caring about the numeric line tag.
 - Use `latest` only as an alias of `stable`; it is not a separate policy channel.
 
 Important:
 
-- Exact release tags such as `0.3.3` must never be republished with different contents.
-- Weekly rebuilds must never move `0.3.3`.
+- Exact release tags such as `0.4.0` must never be republished with different contents.
+- Weekly rebuilds must never move `0.4.0`.
 - `latest` must always point to the newest supported stable line.
 
 ## Release Workflow
 
-The release workflow publishes all of the following tags for `0.3.3`:
+The release workflow publishes all of the following tags for `0.4.0`:
 
-- `0.3.3`
-- `0.3`
+- `0.4.0`
+- `0.4`
 - `stable`
 - `latest`
 
@@ -51,19 +52,19 @@ This keeps a strict split between immutable release artifacts and floating stabl
 
 ## Weekly Rebuild Workflow
 
-The weekly rebuild workflow resolves the latest release tag in the supported `0.3.x` line and rebuilds that source with
+The weekly rebuild workflow resolves the latest release tag in the supported `0.4.x` line and rebuilds that source with
 the current container base image and OS packages.
 
 The rebuild publishes:
 
-- `0.3`
+- `0.4`
 - `stable`
 - `latest`
-- `0.3-rYYYYMMDD`
+- `0.4-rYYYYMMDD`
 
 The rebuild does not publish:
 
-- `0.3.3`
+- `0.4.0`
 
 ## What Weekly Rebuilds Refresh
 
@@ -93,7 +94,7 @@ Development tags are mutable and unsupported for production use.
 
 ## Operational Guidance
 
-- For production fleets that prioritize predictable rollbacks, pin `0.3.3`.
-- For production fleets that prioritize automatic base-image security refreshes inside the supported line, use `0.3` or
+- For production fleets that prioritize predictable rollbacks, pin `0.4.0`.
+- For production fleets that prioritize automatic base-image security refreshes inside the supported line, use `0.4` or
   `stable`.
 - If you use `latest`, treat it exactly the same as `stable`.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -12,15 +12,15 @@ Implemented behavior is defined by:
 
 Active development line:
 
-- `0.4.x` (pre-release)
+- `0.5.x` (planning)
 
 Latest stable release line:
 
-- `0.3.x` (`0.3.3`)
+- `0.4.x` (`0.4.0`)
 
 Primary objective:
 
-- prepare the `0.4.0` release while keeping config migration, docs, and Docker metadata aligned
+- maintain the `0.4.x` stable line while planning the next development cycle
 
 ## Active Priorities
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -10,13 +10,17 @@ Implemented behavior is defined by:
 
 ## Current Line
 
-Active release line:
+Active development line:
 
-- `0.3.x`
+- `0.4.x` (pre-release)
+
+Latest stable release line:
+
+- `0.3.x` (`0.3.3`)
 
 Primary objective:
 
-- stabilize and complete the `0.3.3` release line
+- prepare the `0.4.0` release while keeping config migration, docs, and Docker metadata aligned
 
 ## Active Priorities
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -57,7 +57,7 @@ See also: [auth_control.md](auth_control.md).
 
 ## Operational Baseline
 
-- Use `orenlab/pytmbot:0.3.3` for exact-release reproducibility.
-- Use `orenlab/pytmbot:0.3` or `orenlab/pytmbot:stable` for the supported stable line with weekly base-image refreshes.
+- Use `orenlab/pytmbot:0.4.0` for exact-release reproducibility.
+- Use `orenlab/pytmbot:0.4` or `orenlab/pytmbot:stable` for the supported stable line with weekly base-image refreshes.
 - Run periodic vulnerability scans for container image and host.
 - Review auth/rate-limit/webhook logs regularly.

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -26,7 +26,7 @@ Source of truth:
 ### `config_version`
 
 - Optional, but recommended.
-- Current repository sample value: `0.4.0.dev0` (PEP 440 form of app version `0.4.0-dev`).
+- Current repository sample value: `0.4.0`.
 - Supported values are defined in `get_compatibility_matrix()` inside `pytmbot/models/settings_model.py`.
 - Legacy configs without this field are auto-migrated.
 
@@ -131,7 +131,7 @@ Optional. Required when the `monitor` plugin is enabled.
 ## Minimal Required Configuration
 
 ```yaml
-config_version: "0.4.0.dev0"
+config_version: "0.4.0"
 
 bot_token:
   prod_token:

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -26,7 +26,8 @@ Source of truth:
 ### `config_version`
 
 - Optional, but recommended.
-- Current repository sample value: `0.3.3`.
+- Current repository sample value: `0.4.0.dev0` (PEP 440 form of app version `0.4.0-dev`).
+- Supported values are defined in `get_compatibility_matrix()` inside `pytmbot/models/settings_model.py`.
 - Legacy configs without this field are auto-migrated.
 
 ### `bot_token`
@@ -130,7 +131,7 @@ Optional. Required when the `monitor` plugin is enabled.
 ## Minimal Required Configuration
 
 ```yaml
-config_version: "0.3.3"
+config_version: "0.4.0.dev0"
 
 bot_token:
   prod_token:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyTMBot"
-version = "0.3.3"
+version = "0.4.0-dev"
 description = "Versatile Telegram bot designed for managing Docker containers, monitoring server status, and extending its functionality through a modular plugin system. The bot operates synchronously, simplifying deployment by eliminating the need for webhooks"
 authors = [{ name = "Denis Rozhnovskiy", email = "pytelemonbot@mail.ru" }]
 requires-python = ">=3.12,<4"
@@ -32,12 +32,12 @@ dependencies = [
     "docker>=7.1.0",
     "humanize>=4.15.0",
     "psutil>=7.2.2",
-    "pyotp>=2.9.0",
+    "pyotp>=2.10.0",
     "loguru>=0.7.3",
     "pyyaml>=6.0.3",
     "pygal>=3.1.0",
     "pytelegrambotapi>=4.34.0",
-    "fastapi>=0.136.3",
+    "fastapi>=0.137.1",
     "uvicorn>=0.49.0",
     "influxdb-client>=1.50.0",
     "pypng>=0.20220715.0",
@@ -59,7 +59,7 @@ Repository = "https://github.com/orenlab/pytmbot"
 [dependency-groups]
 dev = [
     "ruff>=0.15.17,<0.16",
-    "pytest>=9.0.3,<10",
+    "pytest>=9.1.0,<10",
     "pytest-cov>=7.1.0,<8",
     "mypy>=2.1.0,<3",
     "codeclone[mcp]>=2.0.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyTMBot"
-version = "0.4.0-dev"
+version = "0.4.0"
 description = "Versatile Telegram bot designed for managing Docker containers, monitoring server status, and extending its functionality through a modular plugin system. The bot operates synchronously, simplifying deployment by eliminating the need for webhooks"
 authors = [{ name = "Denis Rozhnovskiy", email = "pytelemonbot@mail.ru" }]
 requires-python = ">=3.12,<4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ click = ["click>=8.4.1"]
 
 [project.urls]
 Homepage = "https://github.com/orenlab/pytmbot"
+Documentation = "https://orenlab.github.io/pytmbot/"
 Repository = "https://github.com/orenlab/pytmbot"
 
 [dependency-groups]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "emoji>=2.15.0",
     "jinja2>=3.1.6",
     "pydantic>=2.13.3",
-    "pydantic-settings>=2.14.0",
+    "pydantic-settings>=2.14.2",
     "docker>=7.1.0",
     "humanize>=4.15.0",
     "psutil>=7.2.2",
@@ -37,7 +37,7 @@ dependencies = [
     "pyyaml>=6.0.3",
     "pygal>=3.1.0",
     "pytelegrambotapi>=4.34.0",
-    "fastapi>=0.137.1",
+    "fastapi>=0.138.0",
     "uvicorn>=0.49.0",
     "influxdb-client>=1.50.0",
     "pypng>=0.20220715.0",
@@ -58,8 +58,8 @@ Repository = "https://github.com/orenlab/pytmbot"
 
 [dependency-groups]
 dev = [
-    "ruff>=0.15.17,<0.16",
-    "pytest>=9.1.0,<10",
+    "ruff>=0.15.19,<0.16",
+    "pytest>=9.1.1,<10",
     "pytest-cov>=7.1.0,<8",
     "mypy>=2.1.0,<3",
     "codeclone[mcp]>=2.0.2",
@@ -68,7 +68,7 @@ dev = [
     "types-python-dateutil>=2.9.0.20260508,<3",
     "types-requests>=2.33.0.20260513,<3",
     "pre-commit>=4.6.0",
-    "zensical>=0.0.45",
+    "zensical>=0.0.46",
 ]
 
 [project.scripts]

--- a/pytmbot.yaml.sample
+++ b/pytmbot.yaml.sample
@@ -231,7 +231,7 @@ influxdb:
 # - config_version should normally match the running pytmbot version.
 # - This repository sample is prepared for pytmbot 0.4.0-dev.
 # - If config_version is missing or mismatched, startup migrates it to the current app version.
-# - Review docs/settings.md after upgrades to pick up new fields or changed behavior.
+# - Review https://orenlab.github.io/pytmbot/settings/ after upgrades to pick up new fields or changed behavior.
 #
 ################################################################
 # QUICK START GUIDE:
@@ -254,7 +254,7 @@ influxdb:
 # 3. Version Management:
 #    - Keep config_version aligned with your pytmbot version
 #    - Review migration or validation messages in logs after upgrades
-#    - Recheck docs/settings.md when new releases add configuration fields
+#    - Recheck https://orenlab.github.io/pytmbot/settings/ when new releases add configuration fields
 #
 # 4. Security features (automatic):
 #    - Webhook URLs include random tokens for security

--- a/pytmbot.yaml.sample
+++ b/pytmbot.yaml.sample
@@ -1,14 +1,14 @@
 ################################################################
 # pyTMBot Configuration File
-# Version: 0.4.0-dev
-# Compatible with app version: 0.4.0-dev
+# Version: 0.4.0
+# Compatible with app version: 0.4.0
 ################################################################
 
 # Configuration Schema Version
 # Keep this equal to the running pytmbot version.
 # This repository sample targets the current repository runtime version.
 # If omitted or mismatched, pytmbot auto-fills config_version with the current app version during migration.
-config_version: '0.4.0.dev0'
+config_version: '0.4.0'
 
 ################################################################
 # General Bot Settings
@@ -229,7 +229,7 @@ influxdb:
 # VERSIONING NOTES:
 ################################################################
 # - config_version should normally match the running pytmbot version.
-# - This repository sample is prepared for pytmbot 0.4.0-dev.
+# - This repository sample is prepared for pytmbot 0.4.0.
 # - If config_version is missing or mismatched, startup migrates it to the current app version.
 # - Review https://orenlab.github.io/pytmbot/settings/ after upgrades to pick up new fields or changed behavior.
 #
@@ -237,7 +237,7 @@ influxdb:
 # QUICK START GUIDE:
 ################################################################
 # 1. REQUIRED steps to get started:
-#    - Set config_version to match your pytmbot version (this sample uses '0.4.0.dev0')
+#    - Set config_version to match your pytmbot version (this sample uses '0.4.0')
 #    - Replace YOUR_PROD_BOT_TOKEN with token from @BotFather
 #    - Get your IDs with /getmyid (or use @userinfobot as fallback)
 #    - Replace 123456789 with your actual Telegram user ID

--- a/pytmbot.yaml.sample
+++ b/pytmbot.yaml.sample
@@ -1,14 +1,14 @@
 ################################################################
 # pyTMBot Configuration File
-# Version: 0.3.3
-# Compatible with app version: 0.3.3
+# Version: 0.4.0-dev
+# Compatible with app version: 0.4.0-dev
 ################################################################
 
 # Configuration Schema Version
 # Keep this equal to the running pytmbot version.
 # This repository sample targets the current repository runtime version.
 # If omitted or mismatched, pytmbot auto-fills config_version with the current app version during migration.
-config_version: '0.3.3'
+config_version: '0.4.0.dev0'
 
 ################################################################
 # General Bot Settings
@@ -229,7 +229,7 @@ influxdb:
 # VERSIONING NOTES:
 ################################################################
 # - config_version should normally match the running pytmbot version.
-# - This repository sample is prepared for pytmbot 0.3.3.
+# - This repository sample is prepared for pytmbot 0.4.0-dev.
 # - If config_version is missing or mismatched, startup migrates it to the current app version.
 # - Review docs/settings.md after upgrades to pick up new fields or changed behavior.
 #
@@ -237,7 +237,7 @@ influxdb:
 # QUICK START GUIDE:
 ################################################################
 # 1. REQUIRED steps to get started:
-#    - Set config_version to match your pytmbot version (this sample uses '0.3.3')
+#    - Set config_version to match your pytmbot version (this sample uses '0.4.0.dev0')
 #    - Replace YOUR_PROD_BOT_TOKEN with token from @BotFather
 #    - Get your IDs with /getmyid (or use @userinfobot as fallback)
 #    - Replace 123456789 with your actual Telegram user ID

--- a/pytmbot/globals.py
+++ b/pytmbot/globals.py
@@ -68,7 +68,7 @@ def _require_instance[T](
 
 
 # Application metadata - immutable constants
-__version__: Final[str] = "0.4.0-dev"
+__version__: Final[str] = "0.4.0"
 __author__: Final[str] = "Denis Rozhnovskiy <pytelemonbot@mail.ru>"
 __license__: Final[str] = "MIT"
 __repository__: Final[str] = "https://github.com/orenlab/pytmbot"

--- a/pytmbot/globals.py
+++ b/pytmbot/globals.py
@@ -68,7 +68,7 @@ def _require_instance[T](
 
 
 # Application metadata - immutable constants
-__version__: Final[str] = "0.3.3"
+__version__: Final[str] = "0.4.0-dev"
 __author__: Final[str] = "Denis Rozhnovskiy <pytelemonbot@mail.ru>"
 __license__: Final[str] = "MIT"
 __repository__: Final[str] = "https://github.com/orenlab/pytmbot"

--- a/pytmbot/handlers/auth_processing/auth_processing.py
+++ b/pytmbot/handlers/auth_processing/auth_processing.py
@@ -16,6 +16,7 @@ from telebot.types import (
 from pytmbot import exceptions
 from pytmbot.exceptions import ErrorContext
 from pytmbot.globals import get_emoji_converter, get_keyboards
+from pytmbot.handlers.handlers_util.utils import send_bot_message
 from pytmbot.logs import Logger
 from pytmbot.parsers.compiler import Compiler
 
@@ -63,15 +64,20 @@ def _send_response(
         if callback_message is None:
             raise ValueError("Callback query does not contain message")
         bot.delete_message(callback_message.chat.id, callback_message.message_id)
-        bot.send_message(
+        send_bot_message(
+            bot,
             callback_message.chat.id,
             text=response,
             reply_markup=keyboard,
             parse_mode="HTML",
         )
     else:
-        bot.send_message(
-            query.chat.id, text=response, reply_markup=keyboard, parse_mode="HTML"
+        send_bot_message(
+            bot,
+            query.chat.id,
+            text=response,
+            reply_markup=keyboard,
+            parse_mode="HTML",
         )
 
 

--- a/pytmbot/handlers/auth_processing/qrcode_processing.py
+++ b/pytmbot/handlers/auth_processing/qrcode_processing.py
@@ -11,6 +11,7 @@ from telebot.types import Message
 from pytmbot import exceptions
 from pytmbot.exceptions import ErrorContext
 from pytmbot.globals import get_emoji_converter, get_keyboards
+from pytmbot.handlers.handlers_util.utils import send_bot_message, send_main_message
 from pytmbot.logs import Logger
 from pytmbot.parsers.compiler import Compiler
 from pytmbot.utils.message_deletion import (
@@ -69,7 +70,8 @@ def handle_qr_code_message(
         - All operations are logged for security monitoring
     """
     if message.from_user is None:
-        bot.send_message(
+        send_main_message(
+            bot,
             message.chat.id,
             "⚠️ Cannot identify user for QR generation.",
         )
@@ -123,10 +125,12 @@ def handle_qr_code_message(
                     "<i>Please manually delete this message immediately after scanning for security!</i>"
                 )
 
-                bot.send_message(
-                    chat_id=message.chat.id,
+                send_bot_message(
+                    bot,
+                    message.chat.id,
                     text=warning_msg,
                     parse_mode="HTML",
+                    reply_markup=keyboard,
                     reply_to_message_id=sent_message.message_id,
                 )
 
@@ -160,7 +164,12 @@ def handle_qr_code_message(
                 **emojis,
             )
 
-            error_message = bot.send_message(message.chat.id, text=response)
+            error_message = send_bot_message(
+                bot,
+                message.chat.id,
+                text=response,
+                reply_markup=keyboard,
+            )
 
             # Schedule deletion of error message as well (shorter delay)
             deletion_manager.schedule_deletion(
@@ -187,7 +196,12 @@ def handle_qr_code_message(
     except Exception as error:
         # Send user-friendly error message
         error_msg = "⚠️ An error occurred while processing the QR code request."
-        error_message = bot.send_message(message.chat.id, error_msg)
+        error_message = send_bot_message(
+            bot,
+            message.chat.id,
+            text=error_msg,
+            reply_markup=keyboard,
+        )
 
         # Schedule deletion of error message
         try:

--- a/pytmbot/handlers/auth_processing/twofa_processing.py
+++ b/pytmbot/handlers/auth_processing/twofa_processing.py
@@ -30,7 +30,11 @@ from pytmbot.globals import (
     settings,
     var_config,
 )
-from pytmbot.handlers.handlers_util.utils import send_telegram_message
+from pytmbot.handlers.handlers_util.utils import (
+    HANDLER_COMMAND_ERROR_MESSAGE,
+    send_main_message,
+    send_telegram_message,
+)
 from pytmbot.logs import Logger
 from pytmbot.parsers.compiler import Compiler
 from pytmbot.utils import is_valid_totp_code
@@ -135,7 +139,8 @@ def handle_twofa_message(message: Message, bot: TeleBot) -> None:
         None
     """
     if message.from_user is None:
-        bot.send_message(
+        send_main_message(
+            bot,
             message.chat.id,
             "⚠️ Cannot identify user for 2FA flow.",
         )
@@ -151,8 +156,10 @@ def handle_twofa_message(message: Message, bot: TeleBot) -> None:
         _send_totp_code_message(message, bot)
 
     except Exception as error:
-        bot.send_message(
-            message.chat.id, "⚠️ An error occurred while processing the plugins command."
+        send_main_message(
+            bot,
+            message.chat.id,
+            HANDLER_COMMAND_ERROR_MESSAGE,
         )
         raise exceptions.HandlingException(
             ErrorContext(
@@ -185,8 +192,10 @@ def handle_totp_code_verification(message: Message, bot: TeleBot) -> None:
 
     if stop_if(
         message.from_user is None,
-        lambda: bot.send_message(
-            message.chat.id, "⚠️ Cannot identify user for TOTP verification."
+        lambda: send_main_message(
+            bot,
+            message.chat.id,
+            "⚠️ Cannot identify user for TOTP verification.",
         ),
     ):
         return

--- a/pytmbot/handlers/bot_handlers/about.py
+++ b/pytmbot/handlers/bot_handlers/about.py
@@ -12,6 +12,7 @@ from pytmbot import exceptions
 from pytmbot.exceptions import ErrorContext
 from pytmbot.globals import __version__
 from pytmbot.handlers.handlers_util.utils import send_telegram_message
+from pytmbot.keyboards.keyboards import NAV_MAIN
 from pytmbot.logs import Logger
 from pytmbot.parsers.compiler import Compiler
 
@@ -51,11 +52,15 @@ def handle_about_command(message: Message, bot: TeleBot) -> None:
             text=response,
             parse_mode="Markdown",
             link_preview_options=LinkPreviewOptions(is_disabled=True),
+            nav_keyboard=NAV_MAIN,
         )
 
     except Exception as error:
-        bot.send_message(
-            message.chat.id, "⚠️ An error occurred while opening the About screen."
+        send_telegram_message(
+            bot=bot,
+            chat_id=message.chat.id,
+            text="⚠️ An error occurred while opening the About screen.",
+            nav_keyboard=NAV_MAIN,
         )
         raise exceptions.HandlingException(
             ErrorContext(

--- a/pytmbot/handlers/bot_handlers/getmyid.py
+++ b/pytmbot/handlers/bot_handlers/getmyid.py
@@ -12,6 +12,7 @@ from telebot.types import LinkPreviewOptions, Message
 
 from pytmbot import exceptions
 from pytmbot.exceptions import ErrorContext
+from pytmbot.handlers.handlers_util.utils import send_main_message
 from pytmbot.logs import Logger
 from pytmbot.parsers.compiler import Compiler
 from pytmbot.utils.message_deletion import (
@@ -68,7 +69,8 @@ def handle_getmyid(
     """
     try:
         if message.from_user is None:
-            bot.send_message(
+            send_main_message(
+                bot,
                 message.chat.id,
                 "⚠️ Unable to resolve user identity for this message.",
             )
@@ -114,9 +116,10 @@ def handle_getmyid(
         )
 
         # Send the response message
-        sent_message = bot.send_message(
-            chat_id=chat_id,
-            text=answer,
+        sent_message = send_main_message(
+            bot,
+            chat_id,
+            answer,
             parse_mode="HTML",
             link_preview_options=LinkPreviewOptions(is_disabled=True),
         )
@@ -145,9 +148,10 @@ def handle_getmyid(
                 "<i>Please manually delete this message for privacy.</i>"
             )
 
-            bot.send_message(
-                chat_id=chat_id,
-                text=warning_msg,
+            send_main_message(
+                bot,
+                chat_id,
+                warning_msg,
                 parse_mode="HTML",
                 reply_to_message_id=sent_message.message_id,
             )
@@ -166,7 +170,7 @@ def handle_getmyid(
     except Exception as error:
         # Send user-friendly error message
         error_msg = "⚠️ An error occurred while retrieving ID information."
-        bot.send_message(message.chat.id, error_msg)
+        send_main_message(bot, message.chat.id, error_msg)
 
         # Log detailed error information and raise custom exception
         error_context = ErrorContext(

--- a/pytmbot/handlers/bot_handlers/navigation.py
+++ b/pytmbot/handlers/bot_handlers/navigation.py
@@ -11,7 +11,10 @@ from telebot.types import Message
 from pytmbot import exceptions
 from pytmbot.exceptions import ErrorContext
 from pytmbot.globals import get_emoji_converter, get_keyboards
-from pytmbot.handlers.handlers_util.utils import send_telegram_message
+from pytmbot.handlers.handlers_util.utils import (
+    send_main_message,
+    send_telegram_message,
+)
 from pytmbot.logs import Logger
 from pytmbot.parsers.compiler import Compiler
 
@@ -57,8 +60,10 @@ def handle_navigation(message: Message, bot: TeleBot) -> None:
         )
 
     except Exception as error:
-        bot.send_message(
-            message.chat.id, "⚠️ An error occurred while processing the plugins command."
+        send_main_message(
+            bot,
+            message.chat.id,
+            "⚠️ An error occurred while processing the plugins command.",
         )
         raise exceptions.HandlingException(
             ErrorContext(

--- a/pytmbot/handlers/bot_handlers/plugins.py
+++ b/pytmbot/handlers/bot_handlers/plugins.py
@@ -11,7 +11,11 @@ from telebot.types import Message
 from pytmbot import exceptions
 from pytmbot.exceptions import ErrorContext
 from pytmbot.globals import get_emoji_converter, get_keyboards
-from pytmbot.handlers.handlers_util.utils import send_telegram_message
+from pytmbot.handlers.handlers_util.utils import (
+    send_main_message,
+    send_telegram_message,
+)
+from pytmbot.keyboards.keyboards import NAV_MAIN
 from pytmbot.logs import Logger
 from pytmbot.parsers.compiler import Compiler
 from pytmbot.plugins.plugin_manager import PluginManager
@@ -51,6 +55,7 @@ def handle_plugins(message: Message, bot: TeleBot) -> None:
                 chat_id=message.chat.id,
                 text=f"⚠️ {first_name}, no plugins are available right now.",
                 parse_mode="Markdown",
+                nav_keyboard=NAV_MAIN,
             )
             return
 
@@ -87,8 +92,10 @@ def handle_plugins(message: Message, bot: TeleBot) -> None:
         )
 
     except Exception as error:
-        bot.send_message(
-            message.chat.id, "⚠️ An error occurred while opening the plugins menu."
+        send_main_message(
+            bot,
+            message.chat.id,
+            "⚠️ An error occurred while opening the plugins menu.",
         )
         raise exceptions.HandlingException(
             ErrorContext(

--- a/pytmbot/handlers/bot_handlers/start.py
+++ b/pytmbot/handlers/bot_handlers/start.py
@@ -11,7 +11,10 @@ from telebot.types import LinkPreviewOptions, Message
 from pytmbot import exceptions
 from pytmbot.exceptions import ErrorContext
 from pytmbot.globals import get_keyboards
-from pytmbot.handlers.handlers_util.utils import send_telegram_message
+from pytmbot.handlers.handlers_util.utils import (
+    send_main_message,
+    send_telegram_message,
+)
 from pytmbot.logs import Logger
 from pytmbot.parsers.compiler import Compiler
 
@@ -44,8 +47,10 @@ def handle_start(message: Message, bot: TeleBot) -> None:
         )
 
     except Exception as error:
-        bot.send_message(
-            message.chat.id, "⚠️ An error occurred while opening the main menu."
+        send_main_message(
+            bot,
+            message.chat.id,
+            "⚠️ An error occurred while opening the main menu.",
         )
         raise exceptions.HandlingException(
             ErrorContext(

--- a/pytmbot/handlers/docker_handlers/containers.py
+++ b/pytmbot/handlers/docker_handlers/containers.py
@@ -23,6 +23,7 @@ from pytmbot.handlers.docker_handlers.pagination import (
     paginate_items,
 )
 from pytmbot.handlers.handlers_util.utils import (
+    HANDLER_COMMAND_ERROR_MESSAGE,
     send_docker_message,
     send_telegram_message,
 )
@@ -238,7 +239,7 @@ def handle_containers(message: Message, bot: TeleBot) -> None:
         send_docker_message(
             bot,
             message.chat.id,
-            "⚠️ An error occurred while processing the command.",
+            HANDLER_COMMAND_ERROR_MESSAGE,
         )
         raise exceptions.HandlingException(
             ErrorContext(

--- a/pytmbot/handlers/docker_handlers/containers.py
+++ b/pytmbot/handlers/docker_handlers/containers.py
@@ -22,7 +22,10 @@ from pytmbot.handlers.docker_handlers.pagination import (
     build_page_callback_data,
     paginate_items,
 )
-from pytmbot.handlers.handlers_util.utils import send_telegram_message
+from pytmbot.handlers.handlers_util.utils import (
+    send_docker_message,
+    send_telegram_message,
+)
 from pytmbot.logs import Logger
 from pytmbot.parsers.compiler import Compiler
 
@@ -232,8 +235,10 @@ def handle_containers(message: Message, bot: TeleBot) -> None:
         )
 
     except Exception as error:
-        bot.send_message(
-            message.chat.id, "⚠️ An error occurred while processing the command."
+        send_docker_message(
+            bot,
+            message.chat.id,
+            "⚠️ An error occurred while processing the command.",
         )
         raise exceptions.HandlingException(
             ErrorContext(

--- a/pytmbot/handlers/docker_handlers/docker.py
+++ b/pytmbot/handlers/docker_handlers/docker.py
@@ -13,6 +13,7 @@ from pytmbot.adapters.docker.containers_info import fetch_docker_counters
 from pytmbot.exceptions import ErrorContext
 from pytmbot.globals import get_emoji_converter, get_keyboards
 from pytmbot.handlers.handlers_util.utils import (
+    HANDLER_COMMAND_ERROR_MESSAGE,
     send_docker_message,
     send_telegram_message,
 )
@@ -49,7 +50,7 @@ def handle_docker(message: Message, bot: TeleBot) -> None:
         send_docker_message(
             bot,
             message.chat.id,
-            "⚠️ An error occurred while processing the command.",
+            HANDLER_COMMAND_ERROR_MESSAGE,
         )
         raise exceptions.HandlingException(
             ErrorContext(

--- a/pytmbot/handlers/docker_handlers/docker.py
+++ b/pytmbot/handlers/docker_handlers/docker.py
@@ -12,7 +12,10 @@ from pytmbot import exceptions
 from pytmbot.adapters.docker.containers_info import fetch_docker_counters
 from pytmbot.exceptions import ErrorContext
 from pytmbot.globals import get_emoji_converter, get_keyboards
-from pytmbot.handlers.handlers_util.utils import send_telegram_message
+from pytmbot.handlers.handlers_util.utils import (
+    send_docker_message,
+    send_telegram_message,
+)
 from pytmbot.logs import Logger
 from pytmbot.parsers.compiler import Compiler
 
@@ -43,8 +46,10 @@ def handle_docker(message: Message, bot: TeleBot) -> None:
         )
 
     except Exception as error:
-        bot.send_message(
-            message.chat.id, "⚠️ An error occurred while processing the command."
+        send_docker_message(
+            bot,
+            message.chat.id,
+            "⚠️ An error occurred while processing the command.",
         )
         raise exceptions.HandlingException(
             ErrorContext(

--- a/pytmbot/handlers/docker_handlers/images.py
+++ b/pytmbot/handlers/docker_handlers/images.py
@@ -28,7 +28,10 @@ from pytmbot.handlers.docker_handlers.pagination import (
     build_page_callback_data,
     paginate_items,
 )
-from pytmbot.handlers.handlers_util.utils import send_telegram_message
+from pytmbot.handlers.handlers_util.utils import (
+    send_docker_message,
+    send_telegram_message,
+)
 from pytmbot.logs import Logger
 from pytmbot.parsers.compiler import Compiler
 
@@ -849,8 +852,10 @@ def handle_images(message: Message, bot: TeleBot) -> bool:
         )
 
     except Exception as error:
-        bot.send_message(
-            message.chat.id, "⚠️ An error occurred while processing the command."
+        send_docker_message(
+            bot,
+            message.chat.id,
+            "⚠️ An error occurred while processing the command.",
         )
         logger.error(
             "bot.handler.docker.images.fail",

--- a/pytmbot/handlers/docker_handlers/images.py
+++ b/pytmbot/handlers/docker_handlers/images.py
@@ -29,9 +29,11 @@ from pytmbot.handlers.docker_handlers.pagination import (
     paginate_items,
 )
 from pytmbot.handlers.handlers_util.utils import (
+    HANDLER_COMMAND_ERROR_MESSAGE,
     send_docker_message,
     send_telegram_message,
 )
+from pytmbot.keyboards.keyboards import NAV_DOCKER
 from pytmbot.logs import Logger
 from pytmbot.parsers.compiler import Compiler
 
@@ -844,18 +846,19 @@ def handle_images(message: Message, bot: TeleBot) -> bool:
         bot_answer, inline_button = render_images_page(page=1, user_id=user_id)
 
         return send_telegram_message(
-            bot,
-            message.chat.id,
-            bot_answer,
-            inline_button,
-            "HTML",
+            bot=bot,
+            chat_id=message.chat.id,
+            text=bot_answer,
+            reply_markup=inline_button,
+            parse_mode="HTML",
+            nav_keyboard=NAV_DOCKER,
         )
 
     except Exception as error:
         send_docker_message(
             bot,
             message.chat.id,
-            "⚠️ An error occurred while processing the command.",
+            HANDLER_COMMAND_ERROR_MESSAGE,
         )
         logger.error(
             "bot.handler.docker.images.fail",

--- a/pytmbot/handlers/docker_handlers/inline/logs.py
+++ b/pytmbot/handlers/docker_handlers/inline/logs.py
@@ -24,6 +24,7 @@ from pytmbot.handlers.handlers_util.docker import (
 )
 from pytmbot.handlers.handlers_util.utils import send_docker_message
 from pytmbot.handlers.server_handlers.inline.common import edit_callback_message_text
+from pytmbot.keyboards.keyboards import NAV_DOCKER
 from pytmbot.logs import Logger
 from pytmbot.middleware.session_wrapper import two_factor_auth_required
 from pytmbot.parsers.compiler import Compiler
@@ -584,6 +585,7 @@ def _send_logs_as_file(call: CallbackQuery, bot: TeleBot, session: LogsSession) 
             bot=bot,
             chat_id=chat_id,
             navigation_text=LOGS_FILE_DELETED_NAVIGATION_TEXT,
+            nav_keyboard=NAV_DOCKER,
         ),
     )
 

--- a/pytmbot/handlers/docker_handlers/inline/logs.py
+++ b/pytmbot/handlers/docker_handlers/inline/logs.py
@@ -22,6 +22,7 @@ from pytmbot.handlers.handlers_util.docker import (
     get_sanitized_logs,
     show_handler_info,
 )
+from pytmbot.handlers.handlers_util.utils import send_docker_message
 from pytmbot.handlers.server_handlers.inline.common import edit_callback_message_text
 from pytmbot.logs import Logger
 from pytmbot.middleware.session_wrapper import two_factor_auth_required
@@ -594,7 +595,8 @@ def _send_logs_as_file(call: CallbackQuery, bot: TeleBot, session: LogsSession) 
             "This logs file will not be automatically deleted.\n\n"
             "<i>Please manually delete this file message.</i>"
         )
-        bot.send_message(
+        send_docker_message(
+            bot,
             chat_id=chat_id,
             text=warning_message,
             parse_mode="HTML",

--- a/pytmbot/handlers/handlers_util/utils.py
+++ b/pytmbot/handlers/handlers_util/utils.py
@@ -5,25 +5,74 @@ pyTMBot - A simple Telegram bot to handle Docker containers and images,
 also providing basic information about the status of local servers.
 """
 
+from __future__ import annotations
+
+from typing import Any
+
 from telebot import TeleBot
 from telebot.apihelper import ApiTelegramException
-from telebot.types import (
-    ForceReply,
-    InlineKeyboardMarkup,
-    LinkPreviewOptions,
-    ReplyKeyboardMarkup,
-    ReplyKeyboardRemove,
-)
+from telebot.types import LinkPreviewOptions, Message
 
 from pytmbot import exceptions
 from pytmbot.exceptions import ErrorContext
+from pytmbot.keyboards.keyboards import (
+    NAV_DOCKER,
+    NAV_MAIN,
+    NAV_SERVER,
+    ReplyMarkupType,
+    resolve_reply_markup,
+)
 from pytmbot.logs import Logger
 
 logger = Logger()
 
-type ReplyMarkupType = (
-    InlineKeyboardMarkup | ReplyKeyboardMarkup | ForceReply | ReplyKeyboardRemove
-)
+
+def send_bot_message(
+    bot: TeleBot,
+    chat_id: int,
+    text: str,
+    *,
+    reply_markup: ReplyMarkupType | None = None,
+    nav_keyboard: str | None = None,
+    **kwargs: Any,
+) -> Message:
+    """Send a message, optionally preserving the navigation reply keyboard."""
+    return bot.send_message(
+        chat_id=chat_id,
+        text=text,
+        reply_markup=resolve_reply_markup(reply_markup, nav_keyboard=nav_keyboard),
+        **kwargs,
+    )
+
+
+def send_main_message(
+    bot: TeleBot,
+    chat_id: int,
+    text: str,
+    **kwargs: Any,
+) -> Message:
+    """Send a message while keeping the main menu reply keyboard visible."""
+    return send_bot_message(bot, chat_id, text, nav_keyboard=NAV_MAIN, **kwargs)
+
+
+def send_server_message(
+    bot: TeleBot,
+    chat_id: int,
+    text: str,
+    **kwargs: Any,
+) -> Message:
+    """Send a message while keeping the server section reply keyboard visible."""
+    return send_bot_message(bot, chat_id, text, nav_keyboard=NAV_SERVER, **kwargs)
+
+
+def send_docker_message(
+    bot: TeleBot,
+    chat_id: int,
+    text: str,
+    **kwargs: Any,
+) -> Message:
+    """Send a message while keeping the docker section reply keyboard visible."""
+    return send_bot_message(bot, chat_id, text, nav_keyboard=NAV_DOCKER, **kwargs)
 
 
 def send_telegram_message(
@@ -34,6 +83,7 @@ def send_telegram_message(
     parse_mode: str = "HTML",
     link_preview_options: LinkPreviewOptions | None = None,
     reply_to_message_id: int | None = None,
+    nav_keyboard: str | None = None,
 ) -> bool:
     """
     Safely sends a message in Telegram with error handling.
@@ -46,6 +96,7 @@ def send_telegram_message(
         parse_mode: Formatting mode
         link_preview_options: Telegram link preview settings (LinkPreviewOptions | None)
         reply_to_message_id: ID of a message to reply to (int | None)
+        nav_keyboard: Navigation reply keyboard when ``reply_markup`` is omitted
 
     Returns:
         bool: True if the message was sent successfully
@@ -55,14 +106,14 @@ def send_telegram_message(
     """
     try:
         bot.send_message(
-            chat_id,
+            chat_id=chat_id,
             text=(
                 text
                 if len(text) < 4096
                 else "Message is too long. I cut it down to 4096 characters: \n\n"
                 + text[:4000]
             ),
-            reply_markup=reply_markup,
+            reply_markup=resolve_reply_markup(reply_markup, nav_keyboard=nav_keyboard),
             parse_mode=parse_mode,
             link_preview_options=link_preview_options,
             reply_to_message_id=reply_to_message_id,

--- a/pytmbot/handlers/handlers_util/utils.py
+++ b/pytmbot/handlers/handlers_util/utils.py
@@ -7,7 +7,7 @@ also providing basic information about the status of local servers.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Final
 
 from telebot import TeleBot
 from telebot.apihelper import ApiTelegramException
@@ -25,6 +25,18 @@ from pytmbot.keyboards.keyboards import (
 from pytmbot.logs import Logger
 
 logger = Logger()
+
+TELEGRAM_MAX_MESSAGE_LENGTH: Final[int] = 4096
+HANDLER_COMMAND_ERROR_MESSAGE: Final[str] = (
+    "⚠️ An error occurred while processing the command."
+)
+
+
+def truncate_telegram_text(text: str) -> str:
+    """Trim message text to Telegram's maximum message size."""
+    if len(text) < TELEGRAM_MAX_MESSAGE_LENGTH:
+        return text
+    return "Message is too long. I cut it down to 4096 characters: \n\n" + text[:4000]
 
 
 def send_bot_message(
@@ -79,6 +91,7 @@ def send_telegram_message(
     bot: TeleBot,
     chat_id: int,
     text: str,
+    *,
     reply_markup: ReplyMarkupType | None = None,
     parse_mode: str = "HTML",
     link_preview_options: LinkPreviewOptions | None = None,
@@ -88,32 +101,19 @@ def send_telegram_message(
     """
     Safely sends a message in Telegram with error handling.
 
-    Args:
-        bot: TeleBot instance
-        chat_id: Chat ID
-        text: Message text
-        reply_markup: Keyboard markup
-        parse_mode: Formatting mode
-        link_preview_options: Telegram link preview settings (LinkPreviewOptions | None)
-        reply_to_message_id: ID of a message to reply to (int | None)
-        nav_keyboard: Navigation reply keyboard when ``reply_markup`` is omitted
-
     Returns:
         bool: True if the message was sent successfully
 
     Raises:
-        exceptions.PyTMBotErrorHandlerError: In case of a sending error
+        exceptions.ConnectionException: In case of a Telegram API sending error
     """
     try:
-        bot.send_message(
-            chat_id=chat_id,
-            text=(
-                text
-                if len(text) < 4096
-                else "Message is too long. I cut it down to 4096 characters: \n\n"
-                + text[:4000]
-            ),
-            reply_markup=resolve_reply_markup(reply_markup, nav_keyboard=nav_keyboard),
+        send_bot_message(
+            bot,
+            chat_id,
+            truncate_telegram_text(text),
+            reply_markup=reply_markup,
+            nav_keyboard=nav_keyboard,
             parse_mode=parse_mode,
             link_preview_options=link_preview_options,
             reply_to_message_id=reply_to_message_id,

--- a/pytmbot/handlers/server_handlers/cpu.py
+++ b/pytmbot/handlers/server_handlers/cpu.py
@@ -19,6 +19,7 @@ from pytmbot.globals import (
     get_psutil_adapter,
     is_docker_environment,
 )
+from pytmbot.handlers.handlers_util.utils import send_server_message
 from pytmbot.handlers.server_handlers.inline.common import (
     build_user_bound_callback_data,
 )
@@ -99,8 +100,10 @@ def handle_cpu(message: Message, bot: TeleBot) -> None:
         cpu_context = _build_cpu_overview_context()
         if not cpu_context:
             logger.error("bot.handler.server.cpu.get.fail")
-            bot.send_message(
-                message.chat.id, text="⚠️ Failed to get CPU statistics. Try again later."
+            send_server_message(
+                bot,
+                message.chat.id,
+                text="⚠️ Failed to get CPU statistics. Try again later.",
             )
             return None
 
@@ -126,8 +129,10 @@ def handle_cpu(message: Message, bot: TeleBot) -> None:
         return None
 
     except Exception as error:
-        bot.send_message(
-            message.chat.id, "⚠️ An error occurred while processing the command."
+        send_server_message(
+            bot,
+            message.chat.id,
+            "⚠️ An error occurred while processing the command.",
         )
         raise exceptions.HandlingException(
             ErrorContext(

--- a/pytmbot/handlers/server_handlers/cpu.py
+++ b/pytmbot/handlers/server_handlers/cpu.py
@@ -19,7 +19,11 @@ from pytmbot.globals import (
     get_psutil_adapter,
     is_docker_environment,
 )
-from pytmbot.handlers.handlers_util.utils import send_server_message
+from pytmbot.handlers.handlers_util.utils import (
+    HANDLER_COMMAND_ERROR_MESSAGE,
+    send_bot_message,
+    send_server_message,
+)
 from pytmbot.handlers.server_handlers.inline.common import (
     build_user_bound_callback_data,
 )
@@ -120,7 +124,8 @@ def handle_cpu(message: Message, bot: TeleBot) -> None:
             electric_plug=em.get_emoji("electric_plug"),
         )
 
-        bot.send_message(
+        send_bot_message(
+            bot,
             message.chat.id,
             text=cpu_message,
             parse_mode="HTML",
@@ -132,7 +137,7 @@ def handle_cpu(message: Message, bot: TeleBot) -> None:
         send_server_message(
             bot,
             message.chat.id,
-            "⚠️ An error occurred while processing the command.",
+            HANDLER_COMMAND_ERROR_MESSAGE,
         )
         raise exceptions.HandlingException(
             ErrorContext(

--- a/pytmbot/handlers/server_handlers/filesystem.py
+++ b/pytmbot/handlers/server_handlers/filesystem.py
@@ -17,6 +17,7 @@ from pytmbot.globals import (
     get_psutil_adapter,
     is_docker_environment,
 )
+from pytmbot.handlers.handlers_util.utils import send_server_message
 from pytmbot.handlers.server_handlers.inline.common import (
     build_user_bound_callback_data,
 )
@@ -52,7 +53,8 @@ def handle_file_system(message: Message, bot: TeleBot) -> None:
 
         if disk_usage is None:
             logger.error("bot.handler.server.filesystem.disk.usage.fail")
-            bot.send_message(
+            send_server_message(
+                bot,
                 message.chat.id,
                 text="⚠️ Failed to handle disk usage. Please try again later.",
             )
@@ -83,8 +85,10 @@ def handle_file_system(message: Message, bot: TeleBot) -> None:
         return None
 
     except Exception as error:
-        bot.send_message(
-            message.chat.id, "⚠️ An error occurred while processing the command."
+        send_server_message(
+            bot,
+            message.chat.id,
+            "⚠️ An error occurred while processing the command.",
         )
         raise exceptions.HandlingException(
             ErrorContext(

--- a/pytmbot/handlers/server_handlers/filesystem.py
+++ b/pytmbot/handlers/server_handlers/filesystem.py
@@ -17,7 +17,11 @@ from pytmbot.globals import (
     get_psutil_adapter,
     is_docker_environment,
 )
-from pytmbot.handlers.handlers_util.utils import send_server_message
+from pytmbot.handlers.handlers_util.utils import (
+    HANDLER_COMMAND_ERROR_MESSAGE,
+    send_bot_message,
+    send_server_message,
+)
 from pytmbot.handlers.server_handlers.inline.common import (
     build_user_bound_callback_data,
 )
@@ -76,7 +80,8 @@ def handle_file_system(message: Message, bot: TeleBot) -> None:
         user_id = message.from_user.id if message.from_user is not None else None
         keyboard = _build_filesystem_keyboard(user_id)
 
-        bot.send_message(
+        send_bot_message(
+            bot,
             message.chat.id,
             text=bot_answer,
             parse_mode="HTML",
@@ -88,7 +93,7 @@ def handle_file_system(message: Message, bot: TeleBot) -> None:
         send_server_message(
             bot,
             message.chat.id,
-            "⚠️ An error occurred while processing the command.",
+            HANDLER_COMMAND_ERROR_MESSAGE,
         )
         raise exceptions.HandlingException(
             ErrorContext(

--- a/pytmbot/handlers/server_handlers/health_summary.py
+++ b/pytmbot/handlers/server_handlers/health_summary.py
@@ -21,6 +21,7 @@ from pytmbot.globals import (
     get_keyboards,
     get_psutil_adapter,
 )
+from pytmbot.handlers.handlers_util.utils import send_server_message
 from pytmbot.handlers.server_handlers.inline.common import (
     authorize_user_bound_callback,
     build_user_bound_callback_data,
@@ -489,8 +490,10 @@ def handle_system_health(message: Message, bot: TeleBot) -> None:
         )
         return None
     except Exception as error:
-        bot.send_message(
-            message.chat.id, "⚠️ An error occurred while processing the command."
+        send_server_message(
+            bot,
+            message.chat.id,
+            "⚠️ An error occurred while processing the command.",
         )
         raise exceptions.HandlingException(
             ErrorContext(

--- a/pytmbot/handlers/server_handlers/health_summary.py
+++ b/pytmbot/handlers/server_handlers/health_summary.py
@@ -21,7 +21,11 @@ from pytmbot.globals import (
     get_keyboards,
     get_psutil_adapter,
 )
-from pytmbot.handlers.handlers_util.utils import send_server_message
+from pytmbot.handlers.handlers_util.utils import (
+    HANDLER_COMMAND_ERROR_MESSAGE,
+    send_bot_message,
+    send_server_message,
+)
 from pytmbot.handlers.server_handlers.inline.common import (
     authorize_user_bound_callback,
     build_user_bound_callback_data,
@@ -482,7 +486,8 @@ def handle_system_health(message: Message, bot: TeleBot) -> None:
         health_message = _render_health_message()
         user_id = message.from_user.id if message.from_user is not None else None
         keyboard = _build_health_keyboard(user_id)
-        bot.send_message(
+        send_bot_message(
+            bot,
             message.chat.id,
             text=health_message,
             parse_mode="HTML",
@@ -493,7 +498,7 @@ def handle_system_health(message: Message, bot: TeleBot) -> None:
         send_server_message(
             bot,
             message.chat.id,
-            "⚠️ An error occurred while processing the command.",
+            HANDLER_COMMAND_ERROR_MESSAGE,
         )
         raise exceptions.HandlingException(
             ErrorContext(

--- a/pytmbot/handlers/server_handlers/inline/top_process.py
+++ b/pytmbot/handlers/server_handlers/inline/top_process.py
@@ -18,6 +18,7 @@ from pytmbot.globals import (
     get_psutil_adapter,
     is_docker_environment,
 )
+from pytmbot.handlers.handlers_util.utils import HANDLER_COMMAND_ERROR_MESSAGE
 from pytmbot.handlers.server_handlers.cpu import (
     PROCESS_INFO_PREFIX,
     build_cpu_detail_keyboard,
@@ -225,7 +226,7 @@ def handle_process_overview(call: CallbackQuery, bot: TeleBot) -> None:
         edit_callback_message_text(
             call,
             bot,
-            text="⚠️ An error occurred while processing the command.",
+            text=HANDLER_COMMAND_ERROR_MESSAGE,
             reply_markup=keyboard,
         )
         raise exceptions.HandlingException(

--- a/pytmbot/handlers/server_handlers/load_average.py
+++ b/pytmbot/handlers/server_handlers/load_average.py
@@ -11,7 +11,10 @@ from telebot.types import Message
 from pytmbot import exceptions
 from pytmbot.exceptions import ErrorContext
 from pytmbot.globals import get_emoji_converter, get_psutil_adapter
-from pytmbot.handlers.handlers_util.utils import send_server_message
+from pytmbot.handlers.handlers_util.utils import (
+    HANDLER_COMMAND_ERROR_MESSAGE,
+    send_server_message,
+)
 from pytmbot.logs import Logger
 from pytmbot.parsers.compiler import Compiler
 from pytmbot.utils import round_up_tuple
@@ -60,7 +63,7 @@ def handle_load_average(message: Message, bot: TeleBot) -> None:
         send_server_message(
             bot,
             message.chat.id,
-            "⚠️ An error occurred while processing the command.",
+            HANDLER_COMMAND_ERROR_MESSAGE,
         )
         raise exceptions.HandlingException(
             ErrorContext(

--- a/pytmbot/handlers/server_handlers/load_average.py
+++ b/pytmbot/handlers/server_handlers/load_average.py
@@ -11,6 +11,7 @@ from telebot.types import Message
 from pytmbot import exceptions
 from pytmbot.exceptions import ErrorContext
 from pytmbot.globals import get_emoji_converter, get_psutil_adapter
+from pytmbot.handlers.handlers_util.utils import send_server_message
 from pytmbot.logs import Logger
 from pytmbot.parsers.compiler import Compiler
 from pytmbot.utils import round_up_tuple
@@ -35,7 +36,8 @@ def handle_load_average(message: Message, bot: TeleBot) -> None:
 
         if load_average is None:
             logger.error("bot.handler.server.load_average.get.fail")
-            bot.send_message(
+            send_server_message(
+                bot,
                 message.chat.id,
                 text=(
                     "⚠️ Couldn't retrieve load average right now. "
@@ -47,11 +49,18 @@ def handle_load_average(message: Message, bot: TeleBot) -> None:
             "b_load_average.jinja2", context=load_average, **emojis
         )
 
-        bot.send_message(message.chat.id, text=bot_answer, parse_mode="Markdown")
+        send_server_message(
+            bot,
+            message.chat.id,
+            text=bot_answer,
+            parse_mode="Markdown",
+        )
 
     except Exception as error:
-        bot.send_message(
-            message.chat.id, "⚠️ An error occurred while processing the command."
+        send_server_message(
+            bot,
+            message.chat.id,
+            "⚠️ An error occurred while processing the command.",
         )
         raise exceptions.HandlingException(
             ErrorContext(

--- a/pytmbot/handlers/server_handlers/memory.py
+++ b/pytmbot/handlers/server_handlers/memory.py
@@ -16,7 +16,11 @@ from pytmbot.globals import (
     get_keyboards,
     get_psutil_adapter,
 )
-from pytmbot.handlers.handlers_util.utils import send_server_message
+from pytmbot.handlers.handlers_util.utils import (
+    HANDLER_COMMAND_ERROR_MESSAGE,
+    send_bot_message,
+    send_server_message,
+)
 from pytmbot.logs import Logger
 from pytmbot.parsers.compiler import Compiler
 
@@ -66,7 +70,8 @@ def handle_memory(message: Message, bot: TeleBot) -> None:
             abacus=em.get_emoji("abacus"),
         )
 
-        bot.send_message(
+        send_bot_message(
+            bot,
             message.chat.id,
             text=bot_answer,
             reply_markup=keyboard,
@@ -78,7 +83,7 @@ def handle_memory(message: Message, bot: TeleBot) -> None:
         send_server_message(
             bot,
             message.chat.id,
-            "⚠️ An error occurred while processing the command.",
+            HANDLER_COMMAND_ERROR_MESSAGE,
         )
         raise exceptions.HandlingException(
             ErrorContext(

--- a/pytmbot/handlers/server_handlers/memory.py
+++ b/pytmbot/handlers/server_handlers/memory.py
@@ -16,6 +16,7 @@ from pytmbot.globals import (
     get_keyboards,
     get_psutil_adapter,
 )
+from pytmbot.handlers.handlers_util.utils import send_server_message
 from pytmbot.logs import Logger
 from pytmbot.parsers.compiler import Compiler
 
@@ -41,7 +42,8 @@ def handle_memory(message: Message, bot: TeleBot) -> None:
         memory_info = psutil_adapter.get_memory()
         if memory_info is None:
             logger.error("bot.handler.server.memory.get.fail")
-            bot.send_message(
+            send_server_message(
+                bot,
                 message.chat.id,
                 text=(
                     "⚠️ Couldn't retrieve memory usage right now. "
@@ -73,8 +75,10 @@ def handle_memory(message: Message, bot: TeleBot) -> None:
         return None
 
     except Exception as error:
-        bot.send_message(
-            message.chat.id, "⚠️ An error occurred while processing the command."
+        send_server_message(
+            bot,
+            message.chat.id,
+            "⚠️ An error occurred while processing the command.",
         )
         raise exceptions.HandlingException(
             ErrorContext(

--- a/pytmbot/handlers/server_handlers/network.py
+++ b/pytmbot/handlers/server_handlers/network.py
@@ -16,7 +16,11 @@ from pytmbot.globals import (
     get_keyboards,
     get_psutil_adapter,
 )
-from pytmbot.handlers.handlers_util.utils import send_server_message
+from pytmbot.handlers.handlers_util.utils import (
+    HANDLER_COMMAND_ERROR_MESSAGE,
+    send_bot_message,
+    send_server_message,
+)
 from pytmbot.handlers.server_handlers.inline.common import (
     build_user_bound_callback_data,
 )
@@ -81,7 +85,8 @@ def handle_network(message: Message, bot: TeleBot) -> None:
         user_id = message.from_user.id if message.from_user is not None else None
         keyboard = _build_network_keyboard(user_id)
 
-        bot.send_message(
+        send_bot_message(
+            bot,
             message.chat.id,
             text=message_text,
             parse_mode="HTML",
@@ -93,7 +98,7 @@ def handle_network(message: Message, bot: TeleBot) -> None:
         send_server_message(
             bot,
             message.chat.id,
-            "⚠️ An error occurred while processing the command.",
+            HANDLER_COMMAND_ERROR_MESSAGE,
         )
         raise exceptions.HandlingException(
             ErrorContext(

--- a/pytmbot/handlers/server_handlers/network.py
+++ b/pytmbot/handlers/server_handlers/network.py
@@ -16,6 +16,7 @@ from pytmbot.globals import (
     get_keyboards,
     get_psutil_adapter,
 )
+from pytmbot.handlers.handlers_util.utils import send_server_message
 from pytmbot.handlers.server_handlers.inline.common import (
     build_user_bound_callback_data,
 )
@@ -67,7 +68,8 @@ def handle_network(message: Message, bot: TeleBot) -> None:
 
         if network_statistics is None:
             logger.error("bot.handler.server.network.get.fail")
-            bot.send_message(
+            send_server_message(
+                bot,
                 message.chat.id,
                 text="⚠️ An error occurred while getting network statistics",
             )
@@ -88,8 +90,10 @@ def handle_network(message: Message, bot: TeleBot) -> None:
         return None
 
     except Exception as error:
-        bot.send_message(
-            message.chat.id, "⚠️ An error occurred while processing the command."
+        send_server_message(
+            bot,
+            message.chat.id,
+            "⚠️ An error occurred while processing the command.",
         )
         raise exceptions.HandlingException(
             ErrorContext(

--- a/pytmbot/handlers/server_handlers/process.py
+++ b/pytmbot/handlers/server_handlers/process.py
@@ -17,7 +17,11 @@ from pytmbot.globals import (
     get_psutil_adapter,
     is_docker_environment,
 )
-from pytmbot.handlers.handlers_util.utils import send_server_message
+from pytmbot.handlers.handlers_util.utils import (
+    HANDLER_COMMAND_ERROR_MESSAGE,
+    send_bot_message,
+    send_server_message,
+)
 from pytmbot.handlers.server_handlers.inline.common import (
     build_user_bound_callback_data,
 )
@@ -104,8 +108,12 @@ def handle_process(message: Message, bot: TeleBot) -> None:
 
         user_id = message.from_user.id if message.from_user is not None else None
         keyboard = build_process_overview_keyboard(user_id)
-        bot.send_message(
-            message.chat.id, text=message_text, parse_mode="HTML", reply_markup=keyboard
+        send_bot_message(
+            bot,
+            message.chat.id,
+            text=message_text,
+            parse_mode="HTML",
+            reply_markup=keyboard,
         )
         return None
 
@@ -113,7 +121,7 @@ def handle_process(message: Message, bot: TeleBot) -> None:
         send_server_message(
             bot,
             message.chat.id,
-            "⚠️ An error occurred while processing the command.",
+            HANDLER_COMMAND_ERROR_MESSAGE,
         )
         raise exceptions.HandlingException(
             ErrorContext(

--- a/pytmbot/handlers/server_handlers/process.py
+++ b/pytmbot/handlers/server_handlers/process.py
@@ -17,6 +17,7 @@ from pytmbot.globals import (
     get_psutil_adapter,
     is_docker_environment,
 )
+from pytmbot.handlers.handlers_util.utils import send_server_message
 from pytmbot.handlers.server_handlers.inline.common import (
     build_user_bound_callback_data,
 )
@@ -91,7 +92,8 @@ def handle_process(message: Message, bot: TeleBot) -> None:
         message_text = render_process_overview_text()
         if message_text is None:
             logger.error("bot.handler.server.process.get.fail")
-            bot.send_message(
+            send_server_message(
+                bot,
                 message.chat.id,
                 text=(
                     "⚠️ Couldn't retrieve process information right now. "
@@ -108,8 +110,10 @@ def handle_process(message: Message, bot: TeleBot) -> None:
         return None
 
     except Exception as error:
-        bot.send_message(
-            message.chat.id, "⚠️ An error occurred while processing the command."
+        send_server_message(
+            bot,
+            message.chat.id,
+            "⚠️ An error occurred while processing the command.",
         )
         raise exceptions.HandlingException(
             ErrorContext(

--- a/pytmbot/handlers/server_handlers/quickview.py
+++ b/pytmbot/handlers/server_handlers/quickview.py
@@ -19,7 +19,11 @@ from pytmbot.globals import (
     get_keyboards,
     get_psutil_adapter,
 )
-from pytmbot.handlers.handlers_util.utils import send_server_message
+from pytmbot.handlers.handlers_util.utils import (
+    HANDLER_COMMAND_ERROR_MESSAGE,
+    send_bot_message,
+    send_server_message,
+)
 from pytmbot.handlers.server_handlers.inline.common import (
     build_user_bound_callback_data,
 )
@@ -267,7 +271,8 @@ def handle_quick_view(message: Message, bot: TeleBot) -> None:
             template_name="b_quick_view.jinja2", context=context, **emojis
         )
 
-        bot.send_message(
+        send_bot_message(
+            bot,
             message.chat.id,
             text=bot_answer,
             parse_mode="Markdown",
@@ -278,7 +283,7 @@ def handle_quick_view(message: Message, bot: TeleBot) -> None:
         send_server_message(
             bot,
             message.chat.id,
-            "⚠️ An error occurred while processing the command.",
+            HANDLER_COMMAND_ERROR_MESSAGE,
         )
         raise exceptions.HandlingException(
             ErrorContext(

--- a/pytmbot/handlers/server_handlers/quickview.py
+++ b/pytmbot/handlers/server_handlers/quickview.py
@@ -19,6 +19,7 @@ from pytmbot.globals import (
     get_keyboards,
     get_psutil_adapter,
 )
+from pytmbot.handlers.handlers_util.utils import send_server_message
 from pytmbot.handlers.server_handlers.inline.common import (
     build_user_bound_callback_data,
 )
@@ -251,7 +252,8 @@ def handle_quick_view(message: Message, bot: TeleBot) -> None:
 
         if not metrics:
             logger.error("bot.handler.server.quickview.collect.any.fail")
-            bot.send_message(
+            send_server_message(
+                bot,
                 message.chat.id,
                 text="⚠️ Failed to get system metrics. Please try again later.",
             )
@@ -273,8 +275,10 @@ def handle_quick_view(message: Message, bot: TeleBot) -> None:
         )
 
     except Exception as error:
-        bot.send_message(
-            message.chat.id, "⚠️ An error occurred while processing the command."
+        send_server_message(
+            bot,
+            message.chat.id,
+            "⚠️ An error occurred while processing the command.",
         )
         raise exceptions.HandlingException(
             ErrorContext(

--- a/pytmbot/handlers/server_handlers/sensors.py
+++ b/pytmbot/handlers/server_handlers/sensors.py
@@ -18,6 +18,7 @@ from pytmbot.globals import (
     get_keyboards,
     get_psutil_adapter,
 )
+from pytmbot.handlers.handlers_util.utils import send_server_message
 from pytmbot.handlers.server_handlers.inline.common import (
     build_user_bound_callback_data,
 )
@@ -65,7 +66,8 @@ def handle_sensors(message: Message, bot: TeleBot) -> None:
         fan_speeds = fan_getter()
 
         if (sensors_data is None or sensors_data == []) and not fan_speeds:
-            bot.send_message(
+            send_server_message(
+                bot,
                 message.chat.id,
                 text="⚠️ No temperature or fan sensors were found.",
             )
@@ -100,8 +102,10 @@ def handle_sensors(message: Message, bot: TeleBot) -> None:
         )
 
     except Exception as error:
-        bot.send_message(
-            message.chat.id, "⚠️ An error occurred while processing the command."
+        send_server_message(
+            bot,
+            message.chat.id,
+            "⚠️ An error occurred while processing the command.",
         )
         raise exceptions.HandlingException(
             ErrorContext(

--- a/pytmbot/handlers/server_handlers/sensors.py
+++ b/pytmbot/handlers/server_handlers/sensors.py
@@ -18,7 +18,11 @@ from pytmbot.globals import (
     get_keyboards,
     get_psutil_adapter,
 )
-from pytmbot.handlers.handlers_util.utils import send_server_message
+from pytmbot.handlers.handlers_util.utils import (
+    HANDLER_COMMAND_ERROR_MESSAGE,
+    send_bot_message,
+    send_server_message,
+)
 from pytmbot.handlers.server_handlers.inline.common import (
     build_user_bound_callback_data,
 )
@@ -94,7 +98,8 @@ def handle_sensors(message: Message, bot: TeleBot) -> None:
             user_id = message.from_user.id if message.from_user is not None else None
             keyboard = _build_sensors_keyboard(user_id)
 
-        bot.send_message(
+        send_bot_message(
+            bot,
             message.chat.id,
             text=sensors_message,
             parse_mode="HTML",
@@ -105,7 +110,7 @@ def handle_sensors(message: Message, bot: TeleBot) -> None:
         send_server_message(
             bot,
             message.chat.id,
-            "⚠️ An error occurred while processing the command.",
+            HANDLER_COMMAND_ERROR_MESSAGE,
         )
         raise exceptions.HandlingException(
             ErrorContext(

--- a/pytmbot/handlers/server_handlers/server.py
+++ b/pytmbot/handlers/server_handlers/server.py
@@ -11,7 +11,11 @@ from telebot.types import Message
 from pytmbot import exceptions
 from pytmbot.exceptions import ErrorContext
 from pytmbot.globals import get_emoji_converter, get_keyboards
-from pytmbot.handlers.handlers_util.utils import send_server_message
+from pytmbot.handlers.handlers_util.utils import (
+    HANDLER_COMMAND_ERROR_MESSAGE,
+    send_bot_message,
+    send_server_message,
+)
 from pytmbot.logs import Logger
 from pytmbot.parsers.compiler import Compiler
 
@@ -58,7 +62,8 @@ def handle_server(message: Message, bot: TeleBot) -> None:
             template_name="b_server.jinja2", first_name=first_name, **emojis
         )
 
-        bot.send_message(
+        send_bot_message(
+            bot,
             message.chat.id,
             text=response,
             reply_markup=server_keyboard,
@@ -68,7 +73,7 @@ def handle_server(message: Message, bot: TeleBot) -> None:
         send_server_message(
             bot,
             message.chat.id,
-            "⚠️ An error occurred while processing the command.",
+            HANDLER_COMMAND_ERROR_MESSAGE,
         )
         raise exceptions.HandlingException(
             ErrorContext(

--- a/pytmbot/handlers/server_handlers/server.py
+++ b/pytmbot/handlers/server_handlers/server.py
@@ -11,6 +11,7 @@ from telebot.types import Message
 from pytmbot import exceptions
 from pytmbot.exceptions import ErrorContext
 from pytmbot.globals import get_emoji_converter, get_keyboards
+from pytmbot.handlers.handlers_util.utils import send_server_message
 from pytmbot.logs import Logger
 from pytmbot.parsers.compiler import Compiler
 
@@ -64,8 +65,10 @@ def handle_server(message: Message, bot: TeleBot) -> None:
             parse_mode="HTML",
         )
     except Exception as error:
-        bot.send_message(
-            message.chat.id, "⚠️ An error occurred while processing the command."
+        send_server_message(
+            bot,
+            message.chat.id,
+            "⚠️ An error occurred while processing the command.",
         )
         raise exceptions.HandlingException(
             ErrorContext(

--- a/pytmbot/handlers/server_handlers/uptime.py
+++ b/pytmbot/handlers/server_handlers/uptime.py
@@ -16,6 +16,7 @@ from pytmbot.globals import (
     get_keyboards,
     get_psutil_adapter,
 )
+from pytmbot.handlers.handlers_util.utils import send_server_message
 from pytmbot.handlers.server_handlers.inline.common import (
     build_user_bound_callback_data,
 )
@@ -63,7 +64,8 @@ def handle_uptime(message: Message, bot: TeleBot) -> None:
 
         if uptime_data is None:
             logger.error("bot.handler.server.uptime.get.fail")
-            bot.send_message(
+            send_server_message(
+                bot,
                 message.chat.id,
                 text="⚠️ Couldn't retrieve uptime right now. Please try again later.",
             )
@@ -83,8 +85,10 @@ def handle_uptime(message: Message, bot: TeleBot) -> None:
         return None
 
     except Exception as error:
-        bot.send_message(
-            message.chat.id, "⚠️ An error occurred while processing the command."
+        send_server_message(
+            bot,
+            message.chat.id,
+            "⚠️ An error occurred while processing the command.",
         )
         raise exceptions.HandlingException(
             ErrorContext(

--- a/pytmbot/handlers/server_handlers/uptime.py
+++ b/pytmbot/handlers/server_handlers/uptime.py
@@ -16,7 +16,11 @@ from pytmbot.globals import (
     get_keyboards,
     get_psutil_adapter,
 )
-from pytmbot.handlers.handlers_util.utils import send_server_message
+from pytmbot.handlers.handlers_util.utils import (
+    HANDLER_COMMAND_ERROR_MESSAGE,
+    send_bot_message,
+    send_server_message,
+)
 from pytmbot.handlers.server_handlers.inline.common import (
     build_user_bound_callback_data,
 )
@@ -77,7 +81,8 @@ def handle_uptime(message: Message, bot: TeleBot) -> None:
         user_id = message.from_user.id if message.from_user is not None else None
         keyboard = _build_uptime_keyboard(user_id)
 
-        bot.send_message(
+        send_bot_message(
+            bot,
             message.chat.id,
             text=bot_answer,
             reply_markup=keyboard,
@@ -88,7 +93,7 @@ def handle_uptime(message: Message, bot: TeleBot) -> None:
         send_server_message(
             bot,
             message.chat.id,
-            "⚠️ An error occurred while processing the command.",
+            HANDLER_COMMAND_ERROR_MESSAGE,
         )
         raise exceptions.HandlingException(
             ErrorContext(

--- a/pytmbot/keyboards/keyboards.py
+++ b/pytmbot/keyboards/keyboards.py
@@ -14,9 +14,11 @@ from functools import lru_cache
 from typing import Final
 
 from telebot.types import (
+    ForceReply,
     InlineKeyboardButton,
     InlineKeyboardMarkup,
     ReplyKeyboardMarkup,
+    ReplyKeyboardRemove,
 )
 
 from pytmbot.exceptions import KeyboardError
@@ -31,6 +33,17 @@ class KeyboardOperation(StrEnum):
     BUILD_REPLY = "build_reply_keyboard"
     GET_DATA = "get_keyboard_data"
     CONSTRUCT = "construct_keyboard"
+
+
+# Navigation reply-keyboard contexts (values match KeyboardSettings map keys).
+NAV_MAIN: Final[str] = "main_keyboard"
+NAV_SERVER: Final[str] = "server_keyboard"
+NAV_DOCKER: Final[str] = "docker_keyboard"
+NAV_BACK: Final[str] = "back_keyboard"
+
+type ReplyMarkupType = (
+    InlineKeyboardMarkup | ReplyKeyboardMarkup | ForceReply | ReplyKeyboardRemove
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -105,7 +118,10 @@ class Keyboards:
             operation=KeyboardOperation.BUILD_MAIN, data=main_keyboard_data
         ):
             keyboard = ReplyKeyboardMarkup(
-                resize_keyboard=True, one_time_keyboard=True, selective=True
+                resize_keyboard=True,
+                one_time_keyboard=True,
+                selective=True,
+                is_persistent=True,
             )
             keyboard.add(main_keyboard_data)
             return keyboard
@@ -180,6 +196,7 @@ class Keyboards:
                 resize_keyboard=True,
                 row_width=self.DEFAULT_ROW_WIDTH,
                 one_time_keyboard=False,
+                is_persistent=True,
             )
 
             # Build rows with proper chunking
@@ -313,3 +330,29 @@ class Keyboards:
 
             log.trace("bot.keyboards.inline.keyboard.debug", total_buttons=len(buttons))
             return keyboard
+
+
+def build_nav_keyboard(keyboard_type: str = NAV_MAIN) -> ReplyKeyboardMarkup:
+    """Build a persistent reply keyboard for the current navigation section."""
+    keyboards = Keyboards()
+    if keyboard_type == NAV_MAIN:
+        return keyboards.build_reply_keyboard()
+    return keyboards.build_reply_keyboard(keyboard_type=keyboard_type)
+
+
+def resolve_reply_markup(
+    reply_markup: ReplyMarkupType | None,
+    *,
+    nav_keyboard: str | None = None,
+) -> ReplyMarkupType | None:
+    """
+    Prefer an explicit markup; otherwise attach a navigation reply keyboard when requested.
+
+    Inline keyboards are left unchanged. Use ``nav_keyboard=NAV_*`` for text-only replies
+    so Telegram clients keep the section menu visible (notably on iOS).
+    """
+    if reply_markup is not None:
+        return reply_markup
+    if nav_keyboard is None:
+        return None
+    return build_nav_keyboard(nav_keyboard)

--- a/pytmbot/keyboards/keyboards.py
+++ b/pytmbot/keyboards/keyboards.py
@@ -119,7 +119,7 @@ class Keyboards:
         ):
             keyboard = ReplyKeyboardMarkup(
                 resize_keyboard=True,
-                one_time_keyboard=True,
+                one_time_keyboard=False,
                 selective=True,
                 is_persistent=True,
             )

--- a/pytmbot/middleware/access_control.py
+++ b/pytmbot/middleware/access_control.py
@@ -16,6 +16,7 @@ from telebot.handler_backends import BaseMiddleware, CancelUpdate
 from telebot.types import CallbackQuery, Message, User
 
 from pytmbot.globals import settings
+from pytmbot.handlers.handlers_util.utils import send_main_message
 from pytmbot.logs import BaseComponent
 from pytmbot.utils import mask_chat_id, mask_user_id, mask_username
 
@@ -170,7 +171,7 @@ class AccessControl(BaseMiddleware, BaseComponent):
         message_chat = getattr(update, "chat", None)
         chat_id = getattr(message_chat, "id", None)
         if isinstance(chat_id, int):
-            self.bot.send_message(chat_id=chat_id, text=message_text)
+            send_main_message(self.bot, chat_id, message_text)
 
     # codeclone: ignore[dead-code]
     def pre_process(

--- a/pytmbot/middleware/rate_limit.py
+++ b/pytmbot/middleware/rate_limit.py
@@ -15,6 +15,7 @@ from telebot import TeleBot
 from telebot.handler_backends import BaseMiddleware, CancelUpdate
 from telebot.types import CallbackQuery, Message
 
+from pytmbot.handlers.handlers_util.utils import send_main_message
 from pytmbot.logs import BaseComponent
 from pytmbot.utils import mask_user_id, mask_username
 
@@ -265,7 +266,7 @@ class RateLimit(BaseMiddleware, BaseComponent):
                     show_alert=False,
                 )
             elif isinstance(chat_id, int):
-                self.bot.send_message(chat_id=chat_id, text=self.WARNING_MESSAGE)
+                send_main_message(self.bot, chat_id, self.WARNING_MESSAGE)
             message_sent = True
         except Exception as e:
             message_context = {

--- a/pytmbot/models/settings_model.py
+++ b/pytmbot/models/settings_model.py
@@ -33,7 +33,7 @@ def get_app_version() -> str:
         return package_version("pyTMBot")
     except PackageNotFoundError:
         # Source/development fallback when package metadata is unavailable.
-        return "0.4.0.dev0"
+        return "0.4.0"
 
 
 class ConfigVersionError(Exception):
@@ -307,6 +307,11 @@ def get_compatibility_matrix() -> dict[str, dict[str, str]]:
             "min_app": "0.4.0.dev0",
             "max_app": "0.4.0.dev0",
             "description": "Development release for the 0.4.0 line",
+        },
+        "0.4.0": {
+            "min_app": "0.4.0",
+            "max_app": "0.4.0",
+            "description": "Stable release with unified Telegram messaging and dependency refresh",
         },
     }
 

--- a/pytmbot/models/settings_model.py
+++ b/pytmbot/models/settings_model.py
@@ -33,7 +33,7 @@ def get_app_version() -> str:
         return package_version("pyTMBot")
     except PackageNotFoundError:
         # Source/development fallback when package metadata is unavailable.
-        return "0.3.3"
+        return "0.4.0.dev0"
 
 
 class ConfigVersionError(Exception):
@@ -302,6 +302,11 @@ def get_compatibility_matrix() -> dict[str, dict[str, str]]:
             "min_app": "0.3.3",
             "max_app": "0.3.3",
             "description": "Patch release with refreshed dependencies",
+        },
+        "0.4.0.dev0": {
+            "min_app": "0.4.0.dev0",
+            "max_app": "0.4.0.dev0",
+            "description": "Development release for the 0.4.0 line",
         },
     }
 

--- a/pytmbot/plugins/monitor/plugin.py
+++ b/pytmbot/plugins/monitor/plugin.py
@@ -19,6 +19,7 @@ from telebot.types import Message, ReplyKeyboardMarkup
 from pytmbot.adapters.psutil.adapter import PsutilAdapter
 from pytmbot.db.influxdb_interface import InfluxDBInterface
 from pytmbot.globals import get_emoji_converter, get_keyboards
+from pytmbot.handlers.handlers_util.utils import send_bot_message
 from pytmbot.parsers.compiler import Compiler
 from pytmbot.plugins.monitor import config
 from pytmbot.plugins.monitor.methods import SystemMonitorPlugin
@@ -413,7 +414,8 @@ class MonitoringPlugin(PluginInterface):
             computer_disk=em.get_emoji("computer_disk"),
             thermometer=em.get_emoji("thermometer"),
         )
-        return self.bot.send_message(
+        return send_bot_message(
+            self.bot,
             message.chat.id,
             text=response,
             reply_markup=self._build_monitor_keyboard(),
@@ -459,7 +461,8 @@ class MonitoringPlugin(PluginInterface):
             information=em.get_emoji("information"),
             warning=em.get_emoji("warning"),
         )
-        return self.bot.send_message(
+        return send_bot_message(
+            self.bot,
             message.chat.id,
             text=response,
             reply_markup=self._build_monitor_keyboard(),
@@ -479,9 +482,11 @@ class MonitoringPlugin(PluginInterface):
             self.plugin_logger.error(
                 "bot.plugins.monitor.plugin.cpu.snapshot.fail", error=str(error)
             )
-            return self.bot.send_message(
+            return send_bot_message(
+                self.bot,
                 message.chat.id,
                 "⚠️ Failed to collect CPU usage metrics. Please try again.",
+                reply_markup=self._build_monitor_keyboard(),
             )
 
     def handle_memory_usage(self, message: Message) -> Message:
@@ -497,7 +502,8 @@ class MonitoringPlugin(PluginInterface):
         options = "\n".join(
             f"• {preset['label']}" for preset in config.PERIOD_PRESETS.values()
         )
-        return self.bot.send_message(
+        return send_bot_message(
+            self.bot,
             message.chat.id,
             (
                 f"{em.get_emoji('calendar')} <b>Select monitoring period</b>\n"
@@ -515,7 +521,8 @@ class MonitoringPlugin(PluginInterface):
         label = self._normalize_button_text(raw_label)
         period_key = config.PERIOD_LABEL_TO_KEY.get(label)
         if period_key is None:
-            return self.bot.send_message(
+            return send_bot_message(
+                self.bot,
                 message.chat.id,
                 "⚠️ Unknown period option. Use the period keyboard buttons.",
                 reply_markup=self._build_period_keyboard(),

--- a/pytmbot/plugins/outline/plugin.py
+++ b/pytmbot/plugins/outline/plugin.py
@@ -13,6 +13,7 @@ from telebot import TeleBot
 from telebot.types import Message
 
 from pytmbot.globals import get_emoji_converter, get_keyboards
+from pytmbot.handlers.handlers_util.utils import send_bot_message, send_main_message
 from pytmbot.parsers._types import TemplateContext, TemplateValue
 from pytmbot.parsers.compiler import Compiler
 from pytmbot.plugins.outline import config
@@ -110,13 +111,17 @@ class OutlinePlugin(PluginInterface):
             thought_balloon=em.get_emoji("thought_balloon"),
         )
         keyboard = keyboards.build_reply_keyboard(plugin_keyboard_data=config.KEYBOARD)
-        self.bot.send_message(
-            message.chat.id, response, reply_markup=keyboard, parse_mode="Markdown"
+        send_bot_message(
+            self.bot,
+            message.chat.id,
+            response,
+            reply_markup=keyboard,
+            parse_mode="Markdown",
         )
 
     def _reply_html(self, message: Message, text: str) -> Message:
         """Send a simple HTML reply."""
-        return self.bot.send_message(message.chat.id, text, parse_mode="HTML")
+        return send_main_message(self.bot, message.chat.id, text, parse_mode="HTML")
 
     def _get_outline_action_data_or_reply(
         self,

--- a/pytmbot/templates/base_templates/b_about_bot.jinja2
+++ b/pytmbot/templates/base_templates/b_about_bot.jinja2
@@ -9,6 +9,7 @@ I help you manage Docker workloads, inspect server health, and check operational
 • Health summary: `/health`
 
 📚 **Resources**
+• [📖 Documentation](https://orenlab.github.io/pytmbot/)
 • [📝 Report an issue](https://github.com/orenlab/pytmbot/issues)
 • [💻 Source code](https://github.com/orenlab/pytmbot/)
 • [💬 Discussions](https://github.com/orenlab/pytmbot/discussions)

--- a/pytmbot/utils/message_deletion.py
+++ b/pytmbot/utils/message_deletion.py
@@ -474,9 +474,11 @@ _DEFAULT_POST_DELETE_NAVIGATION_TEXT: Final[str] = (
 )
 
 
-def _build_post_delete_navigation_keyboard() -> ReplyKeyboardMarkup:
-    """Restore the main menu reply keyboard after ephemeral messages are removed."""
-    return build_nav_keyboard(NAV_MAIN)
+def _build_post_delete_navigation_keyboard(
+    nav_keyboard: str = NAV_MAIN,
+) -> ReplyKeyboardMarkup:
+    """Restore the section reply keyboard after ephemeral messages are removed."""
+    return build_nav_keyboard(nav_keyboard)
 
 
 def create_post_delete_navigation_callback(
@@ -485,9 +487,10 @@ def create_post_delete_navigation_callback(
     bot: TeleBot,
     chat_id: int,
     navigation_text: str = _DEFAULT_POST_DELETE_NAVIGATION_TEXT,
+    nav_keyboard: str = NAV_MAIN,
 ) -> Callable[[_DeletionResult], None]:
     """
-    Wrap deletion callback to send a back-to-main-menu keyboard after successful deletion.
+    Wrap deletion callback to restore navigation keyboard after successful deletion.
 
     This keeps UX consistent when ephemeral bot messages are auto-removed.
     """
@@ -503,10 +506,13 @@ def create_post_delete_navigation_callback(
 
         if result.status == _DeletionStatus.SUCCESS:
             try:
-                bot.send_message(
-                    chat_id=chat_id,
-                    text=navigation_text,
-                    reply_markup=_build_post_delete_navigation_keyboard(),
+                from pytmbot.handlers.handlers_util.utils import send_bot_message
+
+                send_bot_message(
+                    bot,
+                    chat_id,
+                    navigation_text,
+                    reply_markup=_build_post_delete_navigation_keyboard(nav_keyboard),
                 )
             except Exception as error:
                 _callback_logger.warning(

--- a/pytmbot/utils/message_deletion.py
+++ b/pytmbot/utils/message_deletion.py
@@ -21,6 +21,7 @@ from telebot import TeleBot
 from telebot.apihelper import ApiTelegramException
 from telebot.types import ReplyKeyboardMarkup
 
+from pytmbot.keyboards.keyboards import NAV_MAIN, build_nav_keyboard
 from pytmbot.logs import BaseComponent, Logger
 
 # Type aliases for better readability
@@ -473,11 +474,9 @@ _DEFAULT_POST_DELETE_NAVIGATION_TEXT: Final[str] = (
 )
 
 
-def _build_back_navigation_keyboard() -> ReplyKeyboardMarkup:
-    """Build back-to-main-menu keyboard lazily to avoid import side effects."""
-    from pytmbot.globals import get_keyboards
-
-    return get_keyboards().build_reply_keyboard(keyboard_type="back_keyboard")
+def _build_post_delete_navigation_keyboard() -> ReplyKeyboardMarkup:
+    """Restore the main menu reply keyboard after ephemeral messages are removed."""
+    return build_nav_keyboard(NAV_MAIN)
 
 
 def create_post_delete_navigation_callback(
@@ -507,7 +506,7 @@ def create_post_delete_navigation_callback(
                 bot.send_message(
                     chat_id=chat_id,
                     text=navigation_text,
-                    reply_markup=_build_back_navigation_keyboard(),
+                    reply_markup=_build_post_delete_navigation_keyboard(),
                 )
             except Exception as error:
                 _callback_logger.warning(

--- a/tests/test_auth_handlers.py
+++ b/tests/test_auth_handlers.py
@@ -604,13 +604,13 @@ def test_qrcode_handler_wraps_exceptions(monkeypatch: pytest.MonkeyPatch) -> Non
     assert exc_info.value.context.error_code == "HAND_021"
 
 
-def test_qrcode_deletion_callback_sends_back_navigation(
+def test_qrcode_deletion_callback_sends_main_navigation(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(
         message_deletion_module,
-        "_build_back_navigation_keyboard",
-        lambda: "back-kbd",
+        "_build_post_delete_navigation_keyboard",
+        lambda: "main-kbd",
     )
     bot = _make_bot()
     callback = message_deletion_module.create_post_delete_navigation_callback(
@@ -630,5 +630,5 @@ def test_qrcode_deletion_callback_sends_back_navigation(
 
     assert bot.sent_messages
     assert bot.sent_messages[-1]["chat_id"] == 555
-    assert bot.sent_messages[-1]["reply_markup"] == "back-kbd"
+    assert bot.sent_messages[-1]["reply_markup"] == "main-kbd"
     assert "deleted for security" in str(bot.sent_messages[-1]["text"])

--- a/tests/test_auth_handlers.py
+++ b/tests/test_auth_handlers.py
@@ -610,7 +610,7 @@ def test_qrcode_deletion_callback_sends_main_navigation(
     monkeypatch.setattr(
         message_deletion_module,
         "_build_post_delete_navigation_keyboard",
-        lambda: "main-kbd",
+        lambda nav_keyboard="main_keyboard": "main-kbd",
     )
     bot = _make_bot()
     callback = message_deletion_module.create_post_delete_navigation_callback(

--- a/tests/test_docker_adapter_manager_info_extra.py
+++ b/tests/test_docker_adapter_manager_info_extra.py
@@ -125,7 +125,7 @@ def _docker_settings_stub() -> SimpleNamespace:
             stop_timeout=5,
             restart_timeout=5,
         ),
-        version="0.3.3",
+        version="0.4.0",
     )
 
 
@@ -391,7 +391,7 @@ def test_docker_adapter_security_checks_and_context_sanitization(
             ca_cert=True,
             debug_docker_client=False,
         ),
-        version="0.3.3",
+        version="0.4.0",
     )
     monkeypatch.setattr(docker_adapter_module, "settings", insecure_settings)
     with pytest.warns(RuntimeWarning):
@@ -421,7 +421,7 @@ def test_docker_adapter_tls_config_and_timeout_validation(
             timeout=1,
             strict_access=False,
         ),
-        version="0.3.3",
+        version="0.4.0",
     )
     monkeypatch.setattr(docker_adapter_module, "settings", bad_timeout_settings)
     adapter_with_default_timeout = docker_adapter_module.DockerAdapter()
@@ -433,7 +433,7 @@ def test_docker_adapter_tls_config_and_timeout_validation(
             timeout=1,
             strict_access=True,
         ),
-        version="0.3.3",
+        version="0.4.0",
     )
     monkeypatch.setattr(docker_adapter_module, "settings", strict_bad_timeout_settings)
     with pytest.raises(ValueError):
@@ -450,7 +450,7 @@ def test_docker_adapter_tls_config_and_timeout_validation(
             debug_docker_client=False,
             strict_access=False,
         ),
-        version="0.3.3",
+        version="0.4.0",
     )
     monkeypatch.setattr(docker_adapter_module, "settings", https_settings)
     adapter = docker_adapter_module.DockerAdapter()
@@ -548,7 +548,7 @@ def test_create_tls_config_hostname_paths(monkeypatch: pytest.MonkeyPatch) -> No
                 verify_hostname=True,
                 strict_access=False,
             ),
-            version="0.3.3",
+            version="0.4.0",
         ),
     )
     adapter = docker_adapter_module.DockerAdapter()

--- a/tests/test_handlers_util_utils.py
+++ b/tests/test_handlers_util_utils.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+from typing import Any, cast
+
+import pytest
+from telebot import TeleBot
+from telebot.types import InlineKeyboardMarkup, ReplyKeyboardMarkup
+
+from pytmbot.handlers.handlers_util import utils as utils_module
+from pytmbot.keyboards.keyboards import NAV_DOCKER, NAV_MAIN, NAV_SERVER
+
+
+class _BotStub:
+    def __init__(self) -> None:
+        self.messages: list[dict[str, Any]] = []
+
+    def send_message(self, **kwargs: Any) -> dict[str, Any]:
+        payload = dict(kwargs)
+        self.messages.append(payload)
+        return {"message_id": len(self.messages), **payload}
+
+
+def test_truncate_telegram_text_leaves_short_messages_unchanged() -> None:
+    text = "hello"
+    assert utils_module.truncate_telegram_text(text) == text
+
+
+def test_truncate_telegram_text_truncates_long_messages() -> None:
+    text = "x" * 5000
+    truncated = utils_module.truncate_telegram_text(text)
+    assert len(truncated) < len(text)
+    assert "4096 characters" in truncated
+
+
+def test_send_bot_message_prefers_explicit_reply_markup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    inline = cast(InlineKeyboardMarkup, object())
+
+    def _resolve(
+        reply_markup: object | None,
+        *,
+        nav_keyboard: str | None = None,
+    ) -> object | None:
+        del nav_keyboard
+        return reply_markup
+
+    monkeypatch.setattr(utils_module, "resolve_reply_markup", _resolve)
+    bot = _BotStub()
+    utils_module.send_bot_message(
+        bot,  # type: ignore[arg-type]
+        1,
+        "ok",
+        reply_markup=inline,
+        nav_keyboard=NAV_MAIN,
+    )
+    assert bot.messages[0]["reply_markup"] is inline
+
+
+def test_send_main_server_and_docker_messages_attach_nav_keyboards(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: list[str | None] = []
+
+    def _send_bot_message(
+        _bot: object,
+        _chat_id: int,
+        _text: str,
+        *,
+        nav_keyboard: str | None = None,
+        **kwargs: object,
+    ) -> dict[str, str]:
+        del kwargs
+        captured.append(nav_keyboard)
+        return {"message_id": "1"}
+
+    monkeypatch.setattr(utils_module, "send_bot_message", _send_bot_message)
+    bot = cast(TeleBot, object())
+    utils_module.send_main_message(bot, 1, "main")
+    utils_module.send_server_message(bot, 1, "server")
+    utils_module.send_docker_message(bot, 1, "docker")
+    assert captured == [NAV_MAIN, NAV_SERVER, NAV_DOCKER]
+
+
+def test_send_telegram_message_uses_keyword_arguments(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    def _send_bot_message(
+        _bot: object,
+        chat_id: int,
+        text: str,
+        **kwargs: object,
+    ) -> dict[str, object]:
+        captured["chat_id"] = chat_id
+        captured["text"] = text
+        captured.update(kwargs)
+        return {"message_id": 1}
+
+    monkeypatch.setattr(utils_module, "send_bot_message", _send_bot_message)
+    assert (
+        utils_module.send_telegram_message(
+            object(),  # type: ignore[arg-type]
+            42,
+            "payload",
+            parse_mode="Markdown",
+            nav_keyboard=NAV_MAIN,
+        )
+        is True
+    )
+    assert captured["chat_id"] == 42
+    assert captured["text"] == "payload"
+    assert captured["parse_mode"] == "Markdown"
+    assert captured["nav_keyboard"] == NAV_MAIN
+
+
+def test_build_referer_main_keyboard_is_persistent_and_not_one_time(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import pytmbot.keyboards.keyboards as keyboards_module
+    from pytmbot.settings import KeyboardSettings
+
+    keyboards_module.Keyboards._get_keyboard_data.cache_clear()
+    monkeypatch.setattr(keyboards_module, "keyboard_settings", KeyboardSettings())
+    markup = keyboards_module.Keyboards().build_referer_main_keyboard("Server")
+    assert isinstance(markup, ReplyKeyboardMarkup)
+    assert markup.is_persistent is True
+    assert markup.one_time_keyboard is False

--- a/tests/test_images_handler.py
+++ b/tests/test_images_handler.py
@@ -282,10 +282,12 @@ def test_build_keyboard_render_page_and_handle(monkeypatch: pytest.MonkeyPatch) 
         bot: TeleBot,
         chat_id: int,
         text: str,
+        *,
         reply_markup: _PayloadValue,
         parse_mode: str,
+        **kwargs: _PayloadValue,
     ) -> bool:
-        del bot
+        del bot, kwargs
         sent_payloads.append(
             {
                 "chat_id": chat_id,

--- a/tests/test_keyboards_module.py
+++ b/tests/test_keyboards_module.py
@@ -112,6 +112,37 @@ def test_build_inline_keyboard_truncates_and_validates_buttons() -> None:
         )
 
 
+def test_build_reply_keyboard_is_persistent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    keyboards_module.Keyboards._get_keyboard_data.cache_clear()
+    monkeypatch.setattr(keyboards_module, "keyboard_settings", KeyboardSettings())
+
+    markup = Keyboards().build_reply_keyboard("server_keyboard")
+    assert markup.is_persistent is True
+
+
+def test_build_nav_keyboard_and_resolve_reply_markup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    keyboards_module.Keyboards._get_keyboard_data.cache_clear()
+    monkeypatch.setattr(keyboards_module, "keyboard_settings", KeyboardSettings())
+
+    nav = keyboards_module.build_nav_keyboard(keyboards_module.NAV_MAIN)
+    assert isinstance(nav, ReplyKeyboardMarkup)
+    assert nav.is_persistent is True
+
+    inline = Keyboards().build_inline_keyboard(
+        ButtonData(text="Open", callback_data="ok")
+    )
+    assert keyboards_module.resolve_reply_markup(inline) is inline
+    assert keyboards_module.resolve_reply_markup(None) is None
+    resolved = keyboards_module.resolve_reply_markup(
+        None, nav_keyboard=keyboards_module.NAV_SERVER
+    )
+    assert isinstance(resolved, ReplyKeyboardMarkup)
+
+
 def test_build_referer_keyboards_validation_and_callback_size() -> None:
     keyboard = Keyboards()
 

--- a/tests/test_message_deletion.py
+++ b/tests/test_message_deletion.py
@@ -232,7 +232,7 @@ def test_create_post_delete_navigation_callback_sends_main_keyboard(
     monkeypatch.setattr(
         message_deletion_module,
         "_build_post_delete_navigation_keyboard",
-        lambda: "main-kbd",
+        lambda nav_keyboard="main_keyboard": "main-kbd",
     )
 
     callback = message_deletion_module.create_post_delete_navigation_callback(
@@ -264,3 +264,40 @@ def test_create_post_delete_navigation_callback_sends_main_keyboard(
     assert len(bot.messages) == 1
     assert bot.messages[0]["chat_id"] == 77
     assert bot.messages[0]["reply_markup"] == "main-kbd"
+
+
+def test_create_post_delete_navigation_callback_uses_nav_keyboard(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _NavBot:
+        def __init__(self) -> None:
+            self.messages: list[_PayloadDict] = []
+
+        def send_message(self, **kwargs: _PayloadValue) -> bool:
+            self.messages.append(dict(kwargs))
+            return True
+
+    bot = _NavBot()
+    monkeypatch.setattr(
+        message_deletion_module,
+        "_build_post_delete_navigation_keyboard",
+        lambda nav_keyboard="main_keyboard": f"nav:{nav_keyboard}",
+    )
+
+    callback = message_deletion_module.create_post_delete_navigation_callback(
+        None,
+        bot=cast(TeleBot, bot),
+        chat_id=88,
+        navigation_text="deleted",
+        nav_keyboard="docker_keyboard",
+    )
+    callback(
+        message_deletion_module.DeletionResult(
+            status=message_deletion_module.DeletionStatus.SUCCESS,
+            message_id=1,
+            user_id=1,
+            pending_count=0,
+        )
+    )
+
+    assert bot.messages[0]["reply_markup"] == "nav:docker_keyboard"

--- a/tests/test_message_deletion.py
+++ b/tests/test_message_deletion.py
@@ -210,7 +210,7 @@ def test_cleanup_stale_references(
     assert manager.get_pending_count(6) == 0
 
 
-def test_create_post_delete_navigation_callback_sends_back_keyboard(
+def test_create_post_delete_navigation_callback_sends_main_keyboard(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     class _NavBot:
@@ -231,8 +231,8 @@ def test_create_post_delete_navigation_callback_sends_back_keyboard(
 
     monkeypatch.setattr(
         message_deletion_module,
-        "_build_back_navigation_keyboard",
-        lambda: "back-kbd",
+        "_build_post_delete_navigation_keyboard",
+        lambda: "main-kbd",
     )
 
     callback = message_deletion_module.create_post_delete_navigation_callback(
@@ -263,4 +263,4 @@ def test_create_post_delete_navigation_callback_sends_back_keyboard(
     assert callback_results == ["SUCCESS", "FAILED"]
     assert len(bot.messages) == 1
     assert bot.messages[0]["chat_id"] == 77
-    assert bot.messages[0]["reply_markup"] == "back-kbd"
+    assert bot.messages[0]["reply_markup"] == "main-kbd"

--- a/tests/test_settings_model.py
+++ b/tests/test_settings_model.py
@@ -49,7 +49,7 @@ def test_get_app_version_fallback_when_package_not_installed(
         raise PackageNotFoundError
 
     monkeypatch.setattr(settings_model_module, "package_version", _raise_not_found)
-    assert get_app_version() == "0.3.3"
+    assert get_app_version() == "0.4.0.dev0"
     get_app_version.cache_clear()
 
 
@@ -72,6 +72,9 @@ def test_webhook_config_trusted_proxy_ips_normalization_and_validation() -> None
         ("0.3.2", "0.3.2", False),
         ("0.3.2", "0.3.3", True),
         ("0.3.3", "0.3.3", False),
+        ("0.4.0.dev0", "0.4.0.dev0", False),
+        ("0.4.0-dev", "0.4.0.dev0", False),
+        ("0.3.3", "0.4.0.dev0", True),
     ],
 )
 def test_config_migrator_validate_compatibility(

--- a/tests/test_settings_model.py
+++ b/tests/test_settings_model.py
@@ -49,7 +49,7 @@ def test_get_app_version_fallback_when_package_not_installed(
         raise PackageNotFoundError
 
     monkeypatch.setattr(settings_model_module, "package_version", _raise_not_found)
-    assert get_app_version() == "0.4.0.dev0"
+    assert get_app_version() == "0.4.0"
     get_app_version.cache_clear()
 
 
@@ -65,16 +65,18 @@ def test_webhook_config_trusted_proxy_ips_normalization_and_validation() -> None
     ("config_version", "app_version", "should_raise"),
     [
         (None, "0.2.2", False),
-        ("0.2.1", "0.3.3", True),
-        ("unknown", "0.3.3", True),
-        ("0.3.0.dev0", "0.3.3", True),
-        ("0.3.1", "0.3.3", True),
+        ("0.2.1", "0.4.0", True),
+        ("unknown", "0.4.0", True),
+        ("0.3.0.dev0", "0.4.0", True),
+        ("0.3.1", "0.4.0", True),
         ("0.3.2", "0.3.2", False),
-        ("0.3.2", "0.3.3", True),
+        ("0.3.2", "0.4.0", True),
         ("0.3.3", "0.3.3", False),
+        ("0.3.3", "0.4.0", True),
         ("0.4.0.dev0", "0.4.0.dev0", False),
         ("0.4.0-dev", "0.4.0.dev0", False),
-        ("0.3.3", "0.4.0.dev0", True),
+        ("0.4.0.dev0", "0.4.0", True),
+        ("0.4.0", "0.4.0", False),
     ],
 )
 def test_config_migrator_validate_compatibility(
@@ -91,43 +93,43 @@ def test_config_migrator_validate_compatibility(
 
 def test_config_migrator_check_deprecation_emits_warning() -> None:
     with pytest.warns(DeprecationWarning):
-        check_config_deprecation(None, "0.3.3")
+        check_config_deprecation(None, "0.4.0")
 
     with pytest.warns(DeprecationWarning):
-        check_config_deprecation("0.2.2", "0.3.3")
+        check_config_deprecation("0.2.2", "0.4.0")
 
 
 def test_config_migrator_migrate_config_paths(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(settings_model_module, "get_app_version", lambda: "0.3.3")
+    monkeypatch.setattr(settings_model_module, "get_app_version", lambda: "0.4.0")
     migrator = ConfigMigrator()
 
     legacy: _ConfigDict = {"bot_token": {"prod_token": ["token"]}}
     migrated_legacy = migrator.migrate_config(_as_object_dict(legacy))
-    assert migrated_legacy["config_version"] == "0.3.3"
+    assert migrated_legacy["config_version"] == "0.4.0"
 
     outdated: _ConfigDict = {"config_version": "0.2.2"}
     migrated_outdated = migrator.migrate_config(_as_object_dict(outdated))
-    assert migrated_outdated["config_version"] == "0.3.3"
+    assert migrated_outdated["config_version"] == "0.4.0"
 
-    current: _ConfigDict = {"config_version": "0.3.3"}
+    current: _ConfigDict = {"config_version": "0.4.0"}
     assert (
-        migrator.migrate_config(_as_object_dict(current))["config_version"] == "0.3.3"
+        migrator.migrate_config(_as_object_dict(current))["config_version"] == "0.4.0"
     )
 
 
 def test_settings_model_migration_and_compatibility(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(SettingsModel, "app_version", "0.3.3")
+    monkeypatch.setattr(SettingsModel, "app_version", "0.4.0")
     payload = _base_config()
 
     settings = SettingsModel.model_validate(payload)
-    assert settings.config_version == "0.3.3"
+    assert settings.config_version == "0.4.0"
 
     payload_with_mismatch = dict(payload)
     payload_with_mismatch["config_version"] = "0.2.2"
     upgraded = SettingsModel.model_validate(payload_with_mismatch)
-    assert upgraded.config_version == "0.3.3"
+    assert upgraded.config_version == "0.4.0"
 
 
 def test_access_control_requires_admins_subset_of_allowed_users() -> None:

--- a/tests/test_webhook_more.py
+++ b/tests/test_webhook_more.py
@@ -101,7 +101,11 @@ def test_webhook_verify_telegram_dependency_paths(
     for route in server.app.routes:
         if not isinstance(route, APIRoute):
             continue
-        if route.path == server.WEBHOOK_ROUTE_PATH and "POST" in route.methods:
+        if (
+            route.path == server.WEBHOOK_ROUTE_PATH
+            and route.methods is not None
+            and "POST" in route.methods
+        ):
             dependencies = route.dependant.dependencies
             dependency = dependencies[0] if dependencies else None
             call = getattr(dependency, "call", None)

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,10 @@ revision = 3
 requires-python = ">=3.12, <4"
 resolution-markers = [
     "python_full_version >= '3.15'",
-    "python_full_version < '3.15'",
+    "python_full_version == '3.14.*' and sys_platform == 'win32'",
+    "python_full_version == '3.14.*' and sys_platform != 'win32'",
+    "python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version < '3.14' and sys_platform != 'win32'",
 ]
 
 [[package]]
@@ -148,15 +151,15 @@ wheels = [
 
 [[package]]
 name = "anyio"
-version = "4.13.0"
+version = "4.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "idna" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1c/b5/001890774a9552aff22502b8da382593109ce0c95314abaebbb116567545/anyio-4.14.0.tar.gz", hash = "sha256:b47c1f9ccf73e67021df785332508f99379c68fa7d0684e8e3492cb1d4b23f89", size = 253586, upload-time = "2026-06-15T22:00:49.021Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/16/9826f089383c593cdfc4a6e5aca94d9e91ae1692c57af82c3b2aa5e810f7/anyio-4.14.0-py3-none-any.whl", hash = "sha256:dd9b7a2a9799ed6552fde617b2c5df02b7fdd7d88392fc48101e51bae46164d9", size = 123506, upload-time = "2026-06-15T22:00:47.595Z" },
 ]
 
 [[package]]
@@ -219,11 +222,11 @@ wheels = [
 
 [[package]]
 name = "certifi"
-version = "2026.5.20"
+version = "2026.6.17"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f3/ce/ee2ecad540810a79593028e88299baeae54d346cc7a0d94b6199988b89b1/certifi-2026.5.20.tar.gz", hash = "sha256:69dea482ab64caa7b9f6aba1c6bf48bb6a5448d1c0f1b17ab42ad8c763a5344d", size = 135422, upload-time = "2026-05-20T11:46:50.073Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/c7/424b75da314c1045981bd9777432fad05a9e0c69daa4ed7e308bbaffe405/certifi-2026.6.17.tar.gz", hash = "sha256:024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432", size = 134594, upload-time = "2026-06-17T10:31:07.894Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/59/8c/57e832b7af6d7c5abe66eb3fbe3a3a32f4d11ea23a1aa7131371035be991/certifi-2026.5.20-py3-none-any.whl", hash = "sha256:3c52e209ba0a4ad7aebe60436a4ab349c39e1e602e8c134221e546902ad25897", size = 134134, upload-time = "2026-05-20T11:46:48.578Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl", hash = "sha256:2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db", size = 133289, upload-time = "2026-06-17T10:31:06.348Z" },
 ]
 
 [[package]]
@@ -409,86 +412,71 @@ wheels = [
 
 [[package]]
 name = "coverage"
-version = "7.14.1"
+version = "7.14.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/54/fd/0ab2772530e946e1be1abd0bc09e647ec9b02e88f0867857601fefca8953/coverage-7.14.1.tar.gz", hash = "sha256:30c08f7d90415aa98b3c990385dea2939b0da55f38515e5b369b83655f8523be", size = 920132, upload-time = "2026-05-26T20:41:36.783Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b4/91/0a7c28934e50d8ac9a7b117712d176f2953c3170bccced5eaacfa3e96175/coverage-7.14.3.tar.gz", hash = "sha256:1a7563a443f3d53fdeb040ec8c9f7466aed7ca3dc5891aa09d3ca3625fa4387f", size = 924398, upload-time = "2026-06-22T23:10:25.584Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3d/b7/bdbb725ba02c5b42825b200c940f38b7a54fcad24627b7192f78f8110d76/coverage-7.14.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:a06c76364a9360e33d6d23769aefdf7f66f38e2ffb60ceb1baaa4989d83b695c", size = 220022, upload-time = "2026-05-26T20:39:03.702Z" },
-    { url = "https://files.pythonhosted.org/packages/72/81/fdc0898a55c6219223291ec1a1fe89966ef212ce82276aa0899df84b5de0/coverage-7.14.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fad54e871165f6ec2f536063ac74c3104508a12963e64072ba44bd822de52b0c", size = 220379, upload-time = "2026-05-26T20:39:05.381Z" },
-    { url = "https://files.pythonhosted.org/packages/de/72/de048c4a25e13bce59ac6a339351c10bdf2515e07459afcdaf04dc3143a2/coverage-7.14.1-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:84b535f00655ecafe1d929d1fb00ed5d6fa3051ea643ab2c161a3887b86f294b", size = 251888, upload-time = "2026-05-26T20:39:07.367Z" },
-    { url = "https://files.pythonhosted.org/packages/28/30/300c343f68beb9d4cbb64ec81e58c5b6b80b56927f72d2b38654ac26e013/coverage-7.14.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6b6b0853b895fe0e98cbfc580d1ec3393d9302b4b1e96a77b3f5c91fdab899e6", size = 254624, upload-time = "2026-05-26T20:39:09.037Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/ed/7b25642496e8170b6bac14adce00537c6e5fa2d586159401a4de3e8b49e6/coverage-7.14.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:442cc9c952b2df400cda54bb04ab87330cf2cd08a8692cbbea36773531eb6f37", size = 255739, upload-time = "2026-05-26T20:39:10.889Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/a2/abd210b8c4e29c24e4624916db97bb519097a91034aaeb767f937e7da794/coverage-7.14.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8270544c361ed405a27a060dbc9ed2c124b084d96dfdc2d9a2510482aef981ad", size = 257998, upload-time = "2026-05-26T20:39:12.722Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/24/7c50beed3792fe62f6ce0545c6686ce83379719e2c0276179333d97eae92/coverage-7.14.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:48b283b1dd6372e8de2a7a9a4c4d5dc06f4d4fd209b876f3c88a7a205a0c8f84", size = 252296, upload-time = "2026-05-26T20:39:14.259Z" },
-    { url = "https://files.pythonhosted.org/packages/15/05/0f874628ebcbfc77ead559ff210281ef06a97db08481832e7dd39274a135/coverage-7.14.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5b0c99ba93a07d56f6df340bb79be53202a082b2fdb81bfe6190b741a3470d54", size = 253658, upload-time = "2026-05-26T20:39:15.923Z" },
-    { url = "https://files.pythonhosted.org/packages/99/6f/ca6ad067364b337ef997802115e7ecad2abd2248b05471464b0dea02b4d4/coverage-7.14.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:e471bc5769ff073b058cfadb0d736b56ce067c8560eabeb0da88462df98c23e7", size = 251803, upload-time = "2026-05-26T20:39:17.537Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/30/b9b4d377cd9f40baf228068f5a81faf8450c6228503011bd499708483a50/coverage-7.14.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:f497a1ea81d4cd7c10ddcaa685135b9aabd291af3d55775a9ddf3cb7a364cdd9", size = 255873, upload-time = "2026-05-26T20:39:19.414Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/21/7c721a9e5e6bb88547d30a787aefb97512d3f54c1324c7488d9b3743f7f9/coverage-7.14.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:2222be86d0b54f5dd5a38f45f17f315f737245e857bf0bdedc70734f84a13c02", size = 251372, upload-time = "2026-05-26T20:39:21.169Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/8c/f8ae5a2200130e1503cd7661a6cd3b2b7bacef98277fbf3571fb13f8b766/coverage-7.14.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:85e85586565842f6932abebd4c18bcb1074223dc0b3576e7d173ca710622813a", size = 253245, upload-time = "2026-05-26T20:39:23.097Z" },
-    { url = "https://files.pythonhosted.org/packages/34/62/70a9024672a5f6910517d9628c52c9afbdd3cf8f46426af52bb148a56fff/coverage-7.14.1-cp312-cp312-win32.whl", hash = "sha256:4a28fd227808366b196a75476dced2eb35b351d6766ba9c858dc93319e87f4f1", size = 222567, upload-time = "2026-05-26T20:39:24.868Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/81/8b7cd386839b039ebe1855733b9f9449a8dec5d79564018234f185a7fa70/coverage-7.14.1-cp312-cp312-win_amd64.whl", hash = "sha256:54acdb6674a4661768d7bf7db32dfb9f46ab1d764f8aba6df75ce1a6a088724e", size = 223372, upload-time = "2026-05-26T20:39:26.603Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/ba/b44d472022f620d289d95fa830143235c0c36461c6f2437ea8d51e5481ed/coverage-7.14.1-cp312-cp312-win_arm64.whl", hash = "sha256:99cd41ff91afd94896fea3bc002706b6ae4ce95727d06e4a0f39c0a8d8bd8b1a", size = 221989, upload-time = "2026-05-26T20:39:28.242Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/9e/5f6d56327c62b185225d145191c607e07515294a0aa6338e58805cd4a5ac/coverage-7.14.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:be9f2c802dcfce3f71298303aa5dad0dce440a76c52f2f60dacd8656dab78793", size = 220044, upload-time = "2026-05-26T20:39:29.902Z" },
-    { url = "https://files.pythonhosted.org/packages/75/92/e82aca356744cbbc0f77a0b623e38918c1872361963413a3bab5d0340393/coverage-7.14.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:6223a72fd0e4c7156353ec0f08a5f93623e1d3034d0e2683b9bb8ea674131b1d", size = 220412, upload-time = "2026-05-26T20:39:31.561Z" },
-    { url = "https://files.pythonhosted.org/packages/27/c9/385bde0bf7ed0f4bf3a7ee5367060a86b5d218718cfd6fb943c0f836b34f/coverage-7.14.1-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:7279d2110a28cebc738b6459ecda2771735a4c18465fbbd36b3288fe5ed92247", size = 251412, upload-time = "2026-05-26T20:39:33.337Z" },
-    { url = "https://files.pythonhosted.org/packages/51/8c/23faf6a2343a0d17f960a4bd56c43bc7eb4cf312f774dd6ceebd82c7d8fc/coverage-7.14.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9eeb3fcbc13ba40dfbdb22d01d196a28e9cef9ed4c29b60061a1e0e823a9929d", size = 254008, upload-time = "2026-05-26T20:39:35.009Z" },
-    { url = "https://files.pythonhosted.org/packages/42/06/36f4aa9ca8a815e6036156e80706a67828bb97bd826948244f6996dda957/coverage-7.14.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5f0cfc27c539f07cf5c0a4cfe211d0b6cae039f8f40526dbaa71944e64b50a7b", size = 255241, upload-time = "2026-05-26T20:39:36.71Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/79/95266316352f90f6b1c6736bb413302edfde2453fb32422d3911642691b3/coverage-7.14.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:221c70f316241a78e77e607c227cefc8808d4e08f28d99c04f35694690e940be", size = 257373, upload-time = "2026-05-26T20:39:38.412Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/9c/58316d1f66c488b5fca8a0eb3e98348807813efa8a0d0833b9021be27488/coverage-7.14.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:da028256b04ec30e5e0114b6f76172938c313991f0a2d3d894271315cf5d5e43", size = 251635, upload-time = "2026-05-26T20:39:40.268Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/5a/ca2398a568e16fed7bb713e84ba3603a7164fb65779abe645c565ec890d5/coverage-7.14.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:76a085d7005236a767e3426148b2c407e53ad61695c562f8a81da2d373324901", size = 253373, upload-time = "2026-05-26T20:39:42.145Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/2c/0396562c32deaebe7be51d865b3a41e9a87d7561acafe1a28f53b07e019a/coverage-7.14.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:b553d04b5e778a8e56d57eb134aff42a92718ecba45e79c4764ecfa40efd92ff", size = 251341, upload-time = "2026-05-26T20:39:43.907Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/8f/a94f9221184c9cae1ee115820e3798e48b6b17777a9f19e46fb9a0c8dc74/coverage-7.14.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:46f714d2fb8ae2f4f29f23ada7f1e79b759fff5a70f94a1dac23af204c3ec9e4", size = 255497, upload-time = "2026-05-26T20:39:46.166Z" },
-    { url = "https://files.pythonhosted.org/packages/71/69/505d70e47db1eaebcd002c39759707621ef184cd6b1ae084d9f41293f323/coverage-7.14.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:1896f5e19ff3f0431c7ce2172adc54890fd97f86b59ced8ca1649145d9ffe35d", size = 251159, upload-time = "2026-05-26T20:39:48.03Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/aa/58681c383aa33a9d2ed40a02d7a22fbf780d1fa4d575396365777828198c/coverage-7.14.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:62fd185ef9df3c33d1c8178c5af105f762afbad96038de9a4ae100aa6297ca33", size = 252934, upload-time = "2026-05-26T20:39:49.872Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/fd/11c928cd6bdffc7074bb5965c173d9ebf517fb00205e1da524b98d29ef92/coverage-7.14.1-cp313-cp313-win32.whl", hash = "sha256:ab4af6352741a604c431c6072fce5bee33bf0f20dc7a56618d6bf6bb89e9810c", size = 222584, upload-time = "2026-05-26T20:39:51.68Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/92/fb416fc26d340dcba19518c418d6048e913186e17243982c5e435e41fa7a/coverage-7.14.1-cp313-cp313-win_amd64.whl", hash = "sha256:7af486dabe8954d03b087f0021540897afe084f04e16ff5579e08cc46f871416", size = 223394, upload-time = "2026-05-26T20:39:53.472Z" },
-    { url = "https://files.pythonhosted.org/packages/73/c6/02d56e3867972f77d5036de924643f26c056e848f00452cafb4dbc3c29b4/coverage-7.14.1-cp313-cp313-win_arm64.whl", hash = "sha256:2224f89ffd0c5605ccce1ed7a584da162bc7c55f601ab1c946bc9de31a486b42", size = 222015, upload-time = "2026-05-26T20:39:55.374Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/9e/fcc77914050df73f7662fa1f00902774c79c075a8388ab334074574bf77e/coverage-7.14.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:de286598cc65d2b489411174b1faec2f5a7775fb3201fd925db2a76b4030f37d", size = 220733, upload-time = "2026-05-26T20:39:57.189Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/67/2963cbdaf5cbadec44efa3a1e39eaa1f02df4079585f05387607a221e126/coverage-7.14.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:042c46ded7c288aeb07cf14a28b6c1e10b78fcba40171c3fa1e939377eeef0b5", size = 221086, upload-time = "2026-05-26T20:39:59.019Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/c5/8701645574e11881f2f47d8930f98bc48b5d43b25eb5b4430dfc4a2f9f48/coverage-7.14.1-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:f4ddbe407477f04c45115d1a4e5bc480f753553b534d338d4c3358b1cdd0ea52", size = 262381, upload-time = "2026-05-26T20:40:00.822Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/28/7a64d73598263e0c5abd5084211a8474488d31b3c552ff531c719dfcff62/coverage-7.14.1-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:d13e6725992e2d2fd7d81d4f5241952d13740121dfd501da09201be39b2c003a", size = 264458, upload-time = "2026-05-26T20:40:02.506Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/d8/4969179db9f7eb4df218e69540adf829d1c835f59452513d065d15446802/coverage-7.14.1-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f747dc8edcfe740130f28f32f3995e955494285717e86ee25af51db2219df08a", size = 266884, upload-time = "2026-05-26T20:40:04.421Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/78/a45d5794dbc9bafd97afc96a4377c86c7820d78b6cf51b89bc1d4e919275/coverage-7.14.1-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ced2f09ef276fd58611a1ef502164ad266d2b75174e5a40cabbdb4033f9f6cf2", size = 268022, upload-time = "2026-05-26T20:40:06.298Z" },
-    { url = "https://files.pythonhosted.org/packages/21/cb/4f5e354e9e3e67af96bd4e57113e6db6b22298c7168b13eec408a549903d/coverage-7.14.1-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b84800013769a78ccb9ef4659402e26d06867e337b61ec365f77ad008adea80e", size = 261631, upload-time = "2026-05-26T20:40:08.226Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/49/eced49af4cb996d5d8b7e94e736175c513e4facd3398507b89892b4326d8/coverage-7.14.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:ea8cd6ca0ee9f616aaef3afc6882e32c2cbf18b00d96313ffd76af650574034d", size = 264443, upload-time = "2026-05-26T20:40:10.137Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/d8/5603a88a7c5913a6b54f6cb1a8c46f7b39cbb30f27cd3f492908da09b2d7/coverage-7.14.1-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:aa5e304a873fabddc11e484e9b6b738bd38bd7bed17b09aa84eecf5332e8b8bb", size = 262069, upload-time = "2026-05-26T20:40:11.999Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/59/2ae3cb79da554a06c8619d6c88ea19dd1e4aed4b834b6a83bb1fa243bdc5/coverage-7.14.1-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:5a1c5215be81035e629d5bc756650634d0bf31991038db7a0eccb90f025ce16d", size = 265780, upload-time = "2026-05-26T20:40:13.858Z" },
-    { url = "https://files.pythonhosted.org/packages/af/5f/b130c1dc999031f2648bd25317fbce505ad8d5562079b4ed81e736a84967/coverage-7.14.1-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:79058c47dae6788504b5effb319961bcd72d7240551464b91d474bc0ed186d69", size = 260970, upload-time = "2026-05-26T20:40:16.142Z" },
-    { url = "https://files.pythonhosted.org/packages/87/d1/ec13ccddeb48ec963bdfa72a11224bac2584bd045ba13beca82f8113e9c7/coverage-7.14.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:370c5afae3fa0658e11694a32b24c2778f6bc2d17718121f94ee185e69f26b54", size = 263157, upload-time = "2026-05-26T20:40:18.382Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/c2/cd91ead503045161092d3845f7bb95ea2f25131ce96d3e314dd835d91b9c/coverage-7.14.1-cp313-cp313t-win32.whl", hash = "sha256:3758dd0a7f1fa57365ef2e781df0f0731d38b6e3772259d13dae4bd8a958d4b1", size = 223259, upload-time = "2026-05-26T20:40:20.381Z" },
-    { url = "https://files.pythonhosted.org/packages/71/9f/1e28d97e6bd2c76b07f38b7c02870f1371255ff6717f54eca578fcbbdd0e/coverage-7.14.1-cp313-cp313t-win_amd64.whl", hash = "sha256:6ff665fb023a77386fe11685190cee1f60a7d635994a30d9b0a061533d470fce", size = 224320, upload-time = "2026-05-26T20:40:22.316Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/e0/d936e908f0e1efa55e52b91e01b52f1055cef5e1ab2718493390ed8e2fb8/coverage-7.14.1-cp313-cp313t-win_arm64.whl", hash = "sha256:17a5a241e5997621a956a7f402a7433ef4221e5152809b785bec79e2323799f1", size = 222577, upload-time = "2026-05-26T20:40:24.894Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/34/fc2f101b151af3799a101f0550b0454aa008afdc0add677394ec4aa8ea10/coverage-7.14.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:d5ed429d0b8edaac649e889b4ffcedb6c80b06629a3f93050e3dddfb99235bee", size = 220091, upload-time = "2026-05-26T20:40:27.249Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/a7/1ebae2ab5b961b5c79bb09fe7b3ac99edb190d8be4a8c510b2cf66f46468/coverage-7.14.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:8011224a62280e50dab346960c03cf47aca1a1e09e608c0fb33fd6e0cc8e9500", size = 220421, upload-time = "2026-05-26T20:40:30.084Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/90/92aca9cf0acc95123c96cd1eb1f08917897a7f5dee01e15738922971ec31/coverage-7.14.1-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:12c42ec1e14f553c4f817e989365982e646e27211f10a0f717855b94a79c8906", size = 251466, upload-time = "2026-05-26T20:40:32.542Z" },
-    { url = "https://files.pythonhosted.org/packages/26/2b/78048cbe3b999f6cbf9cc0d90abba6a88a3e0863a8c1c6cbc762f3f8802f/coverage-7.14.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:06144cd511cf2624873a035c5069cf297144f6e77a73ee3d7a55b605ec5efb42", size = 253973, upload-time = "2026-05-26T20:40:34.473Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/21/c2e33b29d1cfde484a19d437afc343c6cd30b08d78cbbf9f5aff14e57b2b/coverage-7.14.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a311d8e1da24be5c1ccf85cbfb06315dbaa1703d5a1eab3f6432c72b837917c8", size = 255318, upload-time = "2026-05-26T20:40:38.154Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/ee/aad2f108d63b769121005302f16bf66db8625c88ceaba466942e09a2607e/coverage-7.14.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c79cead5b5bc584d9c71451cb984d0e3a84e0c0937379c8efcbf27c8d661b851", size = 257633, upload-time = "2026-05-26T20:40:40.164Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/f8/11a2c29b4fd76d9849f81d0bb812ec0017a9396df3217214e38934a8c837/coverage-7.14.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:dcbf65f1f66a26cdd88c35cf68fb4729c5d1cd2e88added72420541dfb212034", size = 251488, upload-time = "2026-05-26T20:40:42.631Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/b8/9a5820de4b8ac2b71d85e3b5fb49108d7469c665f0e2ad0dd7569023e305/coverage-7.14.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:fd86572566fb40189a8260446158235159bc7a82dfbc87a3b39cf4fb57fcec1c", size = 253329, upload-time = "2026-05-26T20:40:45.208Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/ff/f33e4823667e27548e8fd8df44217515303f9808d0ff29817db56f87d990/coverage-7.14.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:7771b601718fdde84832c3a434ca9bbf4ae9adbc49d84198b4110700c3c77c36", size = 251291, upload-time = "2026-05-26T20:40:47.502Z" },
-    { url = "https://files.pythonhosted.org/packages/68/9b/489db0ebb209054766b90a9014a45f6d26eb724c02ec21311c3733b5a644/coverage-7.14.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:39b21e212c55af06fa375e3dbf90a8a8e38792f3a910c580066d23563830ddd5", size = 255564, upload-time = "2026-05-26T20:40:49.372Z" },
-    { url = "https://files.pythonhosted.org/packages/27/b5/16bc2d4c2409b23c7737edb68c83bc89e345f378050549fe1d75ac7d34d5/coverage-7.14.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:f2302660e32562a532b442480121aef8aa61a5bdb20b30bf0adab29f10a5a4b4", size = 251107, upload-time = "2026-05-26T20:40:51.677Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/0c/2629997469a00cd069d588a41c9dc887610f2775ae89d250c4791e65272a/coverage-7.14.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:03a6f93c1ec3b7f2e77b5dbcc5573a2c21f12529a5c6bbe0f16f72303cc2fa4d", size = 252764, upload-time = "2026-05-26T20:40:54.267Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/ee/f78d63c8f079e0d7211c7e2401fa17e311514534ba61bae03e4b287ce4ab/coverage-7.14.1-cp314-cp314-win32.whl", hash = "sha256:8a3ce026d73290f42f08dafecbd82c193a74df280461fbf97300fec51fd133ee", size = 222837, upload-time = "2026-05-26T20:40:56.496Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/b9/be539854f93a70dfbeec69117f33ec70dc42ff0b65b5b07ab8d40d04228e/coverage-7.14.1-cp314-cp314-win_amd64.whl", hash = "sha256:114c95ef29302423b87d159075805f4ab973254a2638a5d7d046c94887cc87d7", size = 223650, upload-time = "2026-05-26T20:40:58.351Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/9e/24e2842fef40f35ac82ba3a7719c8023d011bf3bf652d0675316a9d088a1/coverage-7.14.1-cp314-cp314-win_arm64.whl", hash = "sha256:a07891c3f4805442b31b71e84ba3cf29ed1aa9a428284e06deeb4b23e5b46343", size = 222218, upload-time = "2026-05-26T20:41:00.321Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/1d/ac0a9df5fe31c1e8bdd658074905fc12844a05c1a7e3fdb8417e97c31e23/coverage-7.14.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:1101a5ebb083aecb625ebb6209d4105b58f647b093cb2dc8122d7b33f743cfe1", size = 220822, upload-time = "2026-05-26T20:41:02.281Z" },
-    { url = "https://files.pythonhosted.org/packages/32/cf/f964fd9aff20323f9f1a726c97135f8a76bcd87b92dad141a456a43f3c64/coverage-7.14.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:851b9e1e4e8a4608e77c79714b2e77c0970d2ed7202a05e92ae407817481887b", size = 221084, upload-time = "2026-05-26T20:41:04.593Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/5e/7e5ef2aba844de2b80d678619fcf0841b42e3f37f16411226f3fe4c1016f/coverage-7.14.1-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:d5b89cdfb2ee051b71e8c3c70bd81a9eff81100f736a269136fe1a68efe00474", size = 262454, upload-time = "2026-05-26T20:41:06.641Z" },
-    { url = "https://files.pythonhosted.org/packages/64/62/75809bded87015cc4935524218a2a8ed8dd1a8498bfed30a2f4f7a4b4d34/coverage-7.14.1-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0177614a0370f227888b4e436a7c55686d6a9f90eb1ade2b624ba685a1686e86", size = 264578, upload-time = "2026-05-26T20:41:08.556Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/42/d33392dc14633525012d2d504fa1a33b05538bf535f5c1d64675e5754b78/coverage-7.14.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2d69af5dea2de76fc485a83032a630523f985198b7e25be901ec60181587b01e", size = 266981, upload-time = "2026-05-26T20:41:10.824Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/49/0157c4428c2aca7f1e09d5565930586fd5ae36f1655f08b0daa7cf1fcae1/coverage-7.14.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:35ab22d91de736e8966b980dc355cbcdd2c6dbbcfe275f9a2991bc8a91b3df65", size = 268112, upload-time = "2026-05-26T20:41:12.966Z" },
-    { url = "https://files.pythonhosted.org/packages/96/26/86b9ce71f4092b1ed325ce1421698081df1286b833400b6836912834d6e0/coverage-7.14.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:357d4e32935c36588aaba057d734fa32428c360c9fc2e4442afbf1b646beee6e", size = 261558, upload-time = "2026-05-26T20:41:15Z" },
-    { url = "https://files.pythonhosted.org/packages/20/4c/c311210c5472cf5401d8422b0d7812cdd520f24417673afabda6c323faca/coverage-7.14.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:51bd64741cc6fa065abd300ede1afe5a5291ece9c31da8b24884deda48bcc3f8", size = 264447, upload-time = "2026-05-26T20:41:17.369Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/71/59513f8710ed3e6b0ac0a050a5b7e977bb9c9e880354863b5d00d8809256/coverage-7.14.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:9132cd363a68a4c3daa7c8704a654b1e39d3360f6f5b8ddd470608a945236c07", size = 262048, upload-time = "2026-05-26T20:41:19.309Z" },
-    { url = "https://files.pythonhosted.org/packages/84/8d/bceed32dc494f5bbf50f775cd2e78ca814953942b5ea28d3c1c3ac316f14/coverage-7.14.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:07c6290b1697b862c0478eab545eec949a0d0e4d6d03497f446d706da3b4f2de", size = 265781, upload-time = "2026-05-26T20:41:21.559Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/c5/9348fe40dbfd4991aaf78df2c6c3098bfb2cc834d1fd362a64b4efef855a/coverage-7.14.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:5ea0c297e27133853b4d8a3eb799bff5a2dbd9f2f41537a240d337ac9b4df890", size = 260896, upload-time = "2026-05-26T20:41:23.428Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/92/1ea0f03929da7cf87206b1fa24f4c8e9c158be0455481af29ec0a1f3503f/coverage-7.14.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:01b7733daad0237daa01ef80fe2dfceffc911e6a17fa7b55d14aa8214eaaaecd", size = 263214, upload-time = "2026-05-26T20:41:25.419Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/a9/b2493c054c0e01a643266742ab45e15744e60743f9260cd930c7142b1124/coverage-7.14.1-cp314-cp314t-win32.whl", hash = "sha256:6adc5a36984624a70bf11d7184e20fa0a49aa7c47ffab43804106a1a695ea22e", size = 223624, upload-time = "2026-05-26T20:41:27.795Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/bd/3e1e6a57fccd2d7c83fcdf338e93ba98eb85c6e877dd34731ac585375490/coverage-7.14.1-cp314-cp314t-win_amd64.whl", hash = "sha256:ddf799247318f34dbcd2efa8c95a8d0642674e926bb1774cf9b63dfd2a389d1c", size = 224728, upload-time = "2026-05-26T20:41:30.098Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/d7/31066cf1d2f0c6c797fce911bcfa01dd35642dc6da992a950256097c5860/coverage-7.14.1-cp314-cp314t-win_arm64.whl", hash = "sha256:145986fe66647eb489f18d9a997567a3fd358584c4b5a808769113abc07466af", size = 222752, upload-time = "2026-05-26T20:41:32.123Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/3c/1a983b9a745d7f83d53f057bcc5bf79ba6a2bbc08266b3f0c7d6fe630c9b/coverage-7.14.1-py3-none-any.whl", hash = "sha256:a252f21c27e38347e60111a3266b03827422a7d5525951aceee313aa68bab1d2", size = 211815, upload-time = "2026-05-26T20:41:34.078Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/b0/8a911f6ffe6974dac4df95b468ab9a2899d0e59f0f99a489afeec39f00bc/coverage-7.14.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:3d74ff26299c4879ce3a4d826f9d3d4d556fd285fde7bbce3c0ef5a8ab1cec24", size = 220672, upload-time = "2026-06-22T23:08:26.621Z" },
+    { url = "https://files.pythonhosted.org/packages/36/16/0fc0cb52538783dbbae0934b834f5a58fd5354380ee6cad4a07b15dc845d/coverage-7.14.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:96150a9cf3468ea20f0bc5d0e21b3df8972c31480ef90fa7614b773cc6429665", size = 221035, upload-time = "2026-06-22T23:08:28.372Z" },
+    { url = "https://files.pythonhosted.org/packages/77/e2/421ccfbb48335ac49e93301478cf5d623b0c2bf1c0cadd8e2b2fc6c0c710/coverage-7.14.3-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:27d07a46500ba23515b838dbcf52512026af04090755cf6cc64166d88c9b9a1a", size = 252540, upload-time = "2026-06-22T23:08:30.226Z" },
+    { url = "https://files.pythonhosted.org/packages/06/c2/05b8c890097c61a7f4406b35396b997a635200ded0339eda83dfbe526c5f/coverage-7.14.3-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:621e13c6108234d7960aaf5762ab5c3c00f33c30c15af06dcbff0c73bf112727", size = 255274, upload-time = "2026-06-22T23:08:31.876Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/be/b6d9efe447f8ba3c3c854195f326bd64c54b907d936cd2fdebf8767ec72e/coverage-7.14.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4b60ca6d8af70473491a15a343cbabab2e8f9ea66a4376e81c7aa24876a6f977", size = 256389, upload-time = "2026-06-22T23:08:33.843Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/3c/f26e50acc429e608bc534ac06f0a3c169019c798178ec5e9de3dbc0df9c9/coverage-7.14.3-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c90a7cdd5e380e1ce02f19792e2ac2fbfbf177e35a27e69fd3e873b30d895c0c", size = 258648, upload-time = "2026-06-22T23:08:35.481Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/a2/01c1fabf816c8e1dae197e258edf878a3d3ddc86fbda34b76e5794277d8f/coverage-7.14.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5d788e5fd55347eef06ca0732c77d04a264de67e8ff24631270cdff3767a60cf", size = 252949, upload-time = "2026-06-22T23:08:37.562Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c6/941166dd79c31fd44a13063780ae8d552eee0089a0a0930b9bdb7df554ed/coverage-7.14.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:62c7f79db2851c95ef020e5d28b97afde3daf9f7febcd35b53e05638f729063f", size = 254310, upload-time = "2026-06-22T23:08:39.174Z" },
+    { url = "https://files.pythonhosted.org/packages/10/31/80b1fd028201a961033ce95be3cd1e39e521b3762e6b4a1ac1616cb291e7/coverage-7.14.3-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:90f7608aeb5d9b60b523b9fb2a4ee1973867cc4865a3f26fe6c7577073b70205", size = 252453, upload-time = "2026-06-22T23:08:40.84Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/85/c3d9addd94c4b524f3f4af0232075f5fe7170ce99a1386edff803e5934db/coverage-7.14.3-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:1e3b91f9c4740aeb571ecf82e5e8d8e4ab62d34fcb5a5d4e5baa38c6f7d2857c", size = 256522, upload-time = "2026-06-22T23:08:42.494Z" },
+    { url = "https://files.pythonhosted.org/packages/91/14/e5a0575f73795af3a7a9ae13dadf812e17d32422896839987dc3f86947e1/coverage-7.14.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:c946099774a7699de03cbd0ff0a64e21aed4525eed9d959adde4afe6d15758ef", size = 252023, upload-time = "2026-06-22T23:08:44.243Z" },
+    { url = "https://files.pythonhosted.org/packages/38/9b/9652ee531937ce3b8a63a8896885b2b4a2d56adc30e53c9540c666286d88/coverage-7.14.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:16b206e521feb8b7133a45754643dead0538489cf8b783b90cf5f4e3299625fd", size = 253893, upload-time = "2026-06-22T23:08:46.113Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/05/42678841c8c38e4b08bdfc48269f5a16dfbf5806000fe6a89b4cece3c691/coverage-7.14.3-cp312-cp312-win32.whl", hash = "sha256:ea3169c7116eb6cdf7608c6c7da9ecfcb3da40688e3a510fac2d1d2bafd6dc35", size = 222734, upload-time = "2026-06-22T23:08:47.858Z" },
+    { url = "https://files.pythonhosted.org/packages/df/87/07a4fcee55177a25f1b52331a8e92cf4f2c53b1a9c75ce2981fd59c684ad/coverage-7.14.3-cp312-cp312-win_amd64.whl", hash = "sha256:7ea52fc08f007bcc494d4bb3df3851e95843d881860ba38fe2c64dc100db5e7d", size = 223266, upload-time = "2026-06-22T23:08:49.494Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/34/2b8b66a989282ea7b370beb49f50bab29470dc30bb0b03935b6b802782f7/coverage-7.14.3-cp312-cp312-win_arm64.whl", hash = "sha256:8cec0ad652ec57790970d817490105bd917d783c2f7b38d6b58a0ca312e1a336", size = 222655, upload-time = "2026-06-22T23:08:51.766Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/83/7fefbf5df23ed2b7f489907564a7b34b9b07098128e12e0fdfa92626e456/coverage-7.14.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:47968988b367990ae4ab17523790c38cd125e02c6bfd379b6022be2d40bdc38c", size = 220699, upload-time = "2026-06-22T23:08:53.522Z" },
+    { url = "https://files.pythonhosted.org/packages/31/e6/38c3653ff6d56d704b29241362387ca824e38e15b76fdcb7096538195790/coverage-7.14.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:0ee68f5c34812780f3a7063382c0a9fcbb99985b7ddcdcaa626e4f3fb2e0783a", size = 221068, upload-time = "2026-06-22T23:08:55.571Z" },
+    { url = "https://files.pythonhosted.org/packages/20/86/4f5c45d51c5cd10a128933f0fd235393c9146abbfd2ce2dfa68b3267ead3/coverage-7.14.3-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:fa9e5c6857a7e80fa22ace5cf3550ae392bbfc322f1d8dd2d2d5a8be38cec027", size = 252060, upload-time = "2026-06-22T23:08:57.464Z" },
+    { url = "https://files.pythonhosted.org/packages/82/50/dfce42eff2cecabcd5a9bbad5489449c87db3415f408d23ffee417ce01f6/coverage-7.14.3-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:98a0859b0e98e43e1178a9402e19c8127766b14f7109a374d976e5a62c0e5c73", size = 254657, upload-time = "2026-06-22T23:08:59.453Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/d2/639ceb1bc8038fd0d66768278d5dc22df3391918b8278c2a21aa2602a531/coverage-7.14.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:69918344541ed9c8368566c2adc03c0e33d4550d7faa87d1b35e49b6a3286ea9", size = 255892, upload-time = "2026-06-22T23:09:01.291Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/96/002094a10e113512500dc1e10430a449417e17b0f90f7d496bcb820208b7/coverage-7.14.3-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b7f300ac92cd4b570724c8ffbbd0c130fee298d2447f41d5a3abf58976fae1de", size = 258026, upload-time = "2026-06-22T23:09:03.017Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/ec/286a5d2fad9c4bee59bd724feeb7d5bf8303c6c9200b51d1dd945a9c72b0/coverage-7.14.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:11a7ec9f97ab950f4c5af62229befc7faf208fdbc0116d3902d7e306cf2c5abd", size = 252285, upload-time = "2026-06-22T23:09:04.773Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/7d/a17753a0b12dd48d0d50f5fab079ad99d3be1eac790494d89f3a417ca0b9/coverage-7.14.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a571bd889cd36c5922ce8e42e059f9d37d02301531d11374afa4c87a578625d5", size = 254023, upload-time = "2026-06-22T23:09:06.513Z" },
+    { url = "https://files.pythonhosted.org/packages/86/ef/a76c6ceba6a2c313f905310abf2701d534cada22d372db11731831e9e209/coverage-7.14.3-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:de76caefc8deabb0dd1678b6a980be97d14c8d87e213ac194dbf8b09e96d63fb", size = 251989, upload-time = "2026-06-22T23:09:08.382Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/39/353013a75fec0fb49f7553519f9d52b4441e902e5178c93f38eb6c07cedb/coverage-7.14.3-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:d20a15c622194234161535459affa8f7905830391c9ccfa060d495dbfe3a1c7f", size = 256144, upload-time = "2026-06-22T23:09:10.369Z" },
+    { url = "https://files.pythonhosted.org/packages/29/0e/613878555d734def11c5b20a2701a15cb3781b9e9ea749da27c5f436e928/coverage-7.14.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:b488bd4b23397db62e7a9459129d01ff06a846582a732efd24834b24a6ada498", size = 251808, upload-time = "2026-06-22T23:09:12.057Z" },
+    { url = "https://files.pythonhosted.org/packages/af/76/359c058c9cfdcf1e8b107663881225b03b364a320017eda24a2a66e55102/coverage-7.14.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6a3693b4153394d265f44fb855fdc80e72403024d4d6f91c4871b334d028e4e0", size = 253579, upload-time = "2026-06-22T23:09:13.858Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/d9/4ba2f060933a30ebe363cef9f67a365b0a317e580c0d5d9169d56a73ef1c/coverage-7.14.3-cp313-cp313-win32.whl", hash = "sha256:338b19131ab1a6b767b462bfcbaa692e7ae22f24463e39d49b02a83410ff6b37", size = 222741, upload-time = "2026-06-22T23:09:15.636Z" },
+    { url = "https://files.pythonhosted.org/packages/76/e8/196ebc25d8f34c06d43a6e9c8513c9266ef8dbf3b5672beb1a00cf5e29fa/coverage-7.14.3-cp313-cp313-win_amd64.whl", hash = "sha256:b3d77f7f196abdef7e01415de1bce09f216189e83e58159cfeef2b92d0464994", size = 223283, upload-time = "2026-06-22T23:09:17.478Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/af/51d2aac6417523a286f10fb25f09eb9518a84df9f1151e93ff6871f34849/coverage-7.14.3-cp313-cp313-win_arm64.whl", hash = "sha256:e6230e688c7c3e65cedd41a774eb4ec221adc6bfee13768231015b702d5e4150", size = 222678, upload-time = "2026-06-22T23:09:19.7Z" },
+    { url = "https://files.pythonhosted.org/packages/61/56/14e3b97facbfa1304dd19e676e26599ad359f04714bed32f7f1c5a88efdc/coverage-7.14.3-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:605ab2b566a22bd94834529d66d295c364aba84afd3e5498285c7a524017b1fc", size = 220741, upload-time = "2026-06-22T23:09:21.616Z" },
+    { url = "https://files.pythonhosted.org/packages/12/1d/db378b5cca433b90b893f26dab728b280ddd89f272a1fdfed4aeaa05c686/coverage-7.14.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a3c2134809e80fac091bfed18a6991b5a5eb5df5ae32b17ac4f4f99864b73dd7", size = 221068, upload-time = "2026-06-22T23:09:23.452Z" },
+    { url = "https://files.pythonhosted.org/packages/47/f0/3f8421b20d9c4fcd39be9a8ca3c3fda8bc204b44efbd09fede153afd3e2f/coverage-7.14.3-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:c02efd507227bde9969cab0db8f48890eb3b5dcad6afac57a4792df4133543ce", size = 252117, upload-time = "2026-06-22T23:09:25.458Z" },
+    { url = "https://files.pythonhosted.org/packages/27/ca/59ea35fb99743549ec8b37eff141ece4431fea590c89e536ed8032ef45cf/coverage-7.14.3-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:1bb93c2aa61d2a5b38f1526546d95cf4132cb681e541a337bf8dfd092be816e5", size = 254622, upload-time = "2026-06-22T23:09:27.523Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/25/ec6de51ae7493b92a1cf74d1b763121c29636759167e2a593ba4db5881e4/coverage-7.14.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f502e948e03e866538048bba081c075caaa62e5bda6ea5b7432e45f587eb462a", size = 255968, upload-time = "2026-06-22T23:09:29.43Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/05/c8bfc77823f42b4664fb25842f13b567022f6f84a4c83c8ecbb16734b7cb/coverage-7.14.3-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9973ef2463f8e6cfb61a6324126bb3e17d67a85f22f58d856e583ea2e3ca6501", size = 258284, upload-time = "2026-06-22T23:09:31.397Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/15/1d1b242027124a32b26ef01f82018b8c4ef34ef174aa6aeba7b1eeef48e8/coverage-7.14.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9be4e7d4c5ca0427889f8f9d614bd630c2be741b1de7699bca3b2b6c0e41003e", size = 252143, upload-time = "2026-06-22T23:09:33.256Z" },
+    { url = "https://files.pythonhosted.org/packages/74/b6/d2a9842fd2a5d7d27f1ac851c043a734a494ad75402c5331db3da79ed691/coverage-7.14.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a574912f3bde4b0619f6e97d01aa590b70998859244793769eb3a6df78ee56d3", size = 253976, upload-time = "2026-06-22T23:09:35.351Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/30/e1600ddf7e226db5558bb5323d2186fff00f505c4b764643ec89ce5d8175/coverage-7.14.3-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:e343fb086c9cd780b38622fea7c369acd64c1a0724312149b5d769c387a2b1f5", size = 251942, upload-time = "2026-06-22T23:09:37.313Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/2c/9159de64f9dd648e324328d588a44cfab1e331eb5259ce1141afe2a92dfb/coverage-7.14.3-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:3c68df8e61f1e09633fefc7538297145623957a048534368c9d212782aa5e845", size = 256220, upload-time = "2026-06-22T23:09:39.165Z" },
+    { url = "https://files.pythonhosted.org/packages/91/67/b7f536cc2c124f48e91b22fbb741d2261f4e3d310faf6f76007f47566e5d/coverage-7.14.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:3e5b550a128419373c2f6cec28a244207013ef15f5cbcff6a5ca09d1dfaaf027", size = 251756, upload-time = "2026-06-22T23:09:41.056Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/ec/f3718038e2d4860c715a55428377ca7f6c75872caf98cabd982e1d76967d/coverage-7.14.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2bfc4dd0a912329eccc7484a7d0b2a38032b38c40663b1e1ac595f10c457954b", size = 253413, upload-time = "2026-06-22T23:09:43.306Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/a5/91f11efeef89b3cc9b30461128db15b0511ef813ab889a7b7ab636b3a497/coverage-7.14.3-cp314-cp314-win32.whl", hash = "sha256:0423d64c013057a06e70f070f073cec4b0cbc7d2b27f3c7007292f2ff1d52965", size = 222946, upload-time = "2026-06-22T23:09:45.261Z" },
+    { url = "https://files.pythonhosted.org/packages/58/fd/98ac9f524d9ec378de831c034dbdeb544ca7ef7d2d9c9996daf232a037fd/coverage-7.14.3-cp314-cp314-win_amd64.whl", hash = "sha256:92c22e19ce64ca3f2ad751f16f14df1468b4c231bd6af97185063a9c292a0cb3", size = 223436, upload-time = "2026-06-22T23:09:47.177Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/a0/7cd612d650a772a0ae80144443406bf61981c896c3d57c9e6e79fb2cdbd1/coverage-7.14.3-cp314-cp314-win_arm64.whl", hash = "sha256:41de778bd41780586e2b04912079c73089ab5d839624e28db3bdb26de638da92", size = 222861, upload-time = "2026-06-22T23:09:49.384Z" },
+    { url = "https://files.pythonhosted.org/packages/55/57/017353fab573779c0d00448e47d102edd36c792f7b6f233a4d89a7a08384/coverage-7.14.3-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:8427f370ca67db4c975d2a26acfc0e5783ca0b52444dbc50278ace0f35445949", size = 221474, upload-time = "2026-06-22T23:09:51.417Z" },
+    { url = "https://files.pythonhosted.org/packages/69/92/90cf1f1a5c468a9c1b7ba2716e0e205293ad9b02f5f573a6de4318b15ba1/coverage-7.14.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:d8e88f335544a47e22ae2e45b344772925ec65166555c958720d5ed971880891", size = 221738, upload-time = "2026-06-22T23:09:53.487Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/c0/4df964fa539f8399fd7679c09c472d73744de334686fd3f01e3a2465ce4e/coverage-7.14.3-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:beaab199b9e5ceaf5a225e16a9d4df136f2a1eae0a5c20de1e277c8a5225f388", size = 263101, upload-time = "2026-06-22T23:09:55.895Z" },
+    { url = "https://files.pythonhosted.org/packages/06/76/e5d33b2576ae3bf2be2058cd1cae57774b61e400f2c3c58f3783dc2ffb4a/coverage-7.14.3-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b3ff255799f5a1676c71c1c32ec01fd043aa09d57b3d95764b24992757184784", size = 265225, upload-time = "2026-06-22T23:09:57.904Z" },
+    { url = "https://files.pythonhosted.org/packages/61/d2/e52419afe391a39ba27fdefaf0737d8e34bf03faef6ab3b3006545bbd0d0/coverage-7.14.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:878832eaac515b62decfa76965aed558775f86bf1fc8cca76993c0c84ae31aed", size = 267643, upload-time = "2026-06-22T23:09:59.938Z" },
+    { url = "https://files.pythonhosted.org/packages/58/7a/f2625d8d5006b6b20fba5afaef00b24a763fe96476ea798a3076cbc1f84e/coverage-7.14.3-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:611e62cb9386096d81b63e0a05330750268617231e7bd598e1fe77482a2c58a5", size = 268762, upload-time = "2026-06-22T23:10:01.943Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/bf/908024006bba57127354d74e938954b9c3cd765cc2e0412dc9c37b415cda/coverage-7.14.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:02c41de2a88011b893050fc9830267d927a50a215f7ad5ec17349db7090ccf26", size = 262208, upload-time = "2026-06-22T23:10:03.954Z" },
+    { url = "https://files.pythonhosted.org/packages/34/a0/d4f9296441b909817442fdb26bd77a698f08272ec683a7394b00eb2e47a0/coverage-7.14.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:526ce9721116af23b1065089f0b75046fe521e7772ab94b641cd66b7a0421889", size = 265096, upload-time = "2026-06-22T23:10:05.936Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/da/4ae4f3f4e477b56a4ce1e5c48a35eff38a94b50130ce5bdc897024741cfc/coverage-7.14.3-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:e4ed44705ca4bead6fc977a8b741f2145608289b33c8a9b42a95d0f15aedbf4d", size = 262699, upload-time = "2026-06-22T23:10:07.973Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/7a/6927148073ff32856d78baa77b4ddc07a9be7e90020f9db0661c4ca523a1/coverage-7.14.3-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:2415902f385a23dcc4ccd26e0ba803249a169af6a930c003a4c715eeb9a5444e", size = 266433, upload-time = "2026-06-22T23:10:10.145Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/a7/774f658dbe9c4c3f5daa86a87e0459ac3832e4e3cc67affe078547f727b9/coverage-7.14.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:b75ee850fc2d7c831e883220c445b035f2224de2ba6103f1e56dbd237ab913f7", size = 261547, upload-time = "2026-06-22T23:10:12.191Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/14/a0c18c0376c43cbf973f43ef6ca20019c950597180e6396232f7b6a27102/coverage-7.14.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:dc9b4e35e7c3920e925ba7f14886fd5fbe481232754624e832ddba66c7535635", size = 263859, upload-time = "2026-06-22T23:10:14.492Z" },
+    { url = "https://files.pythonhosted.org/packages/10/ac/43a3d0f460af524b131a6191805bc5d18b806ab4e828fbf82e8c8c3af446/coverage-7.14.3-cp314-cp314t-win32.whl", hash = "sha256:7b27c822a8161afbe48e99f1adfb098d270ae7e0f7d7b0555ce110529bdb69cc", size = 223250, upload-time = "2026-06-22T23:10:16.758Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/5f/d5e5c56b0712e96ce8f69fe7dbf229ff938b437bc50862743c8a0d2cea84/coverage-7.14.3-cp314-cp314t-win_amd64.whl", hash = "sha256:39e1dbbb6ff2c338e0196a482558a792a1de3aa64261196f5cdb3da016ad9cda", size = 224082, upload-time = "2026-06-22T23:10:19.23Z" },
+    { url = "https://files.pythonhosted.org/packages/62/35/947cbd5be1d3bcbbdc43d6791de8a56c6501903311d42915ae06a82815f0/coverage-7.14.3-cp314-cp314t-win_arm64.whl", hash = "sha256:68520c90babfa2d560eca6d497921ed3a4f469623bd709733124491b2aa8ef3f", size = 223400, upload-time = "2026-06-22T23:10:21.24Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/e3/a0aa32bfa3a081951f60a23bc0e7b512891ef0eecda1153cf1d8ba36c6b1/coverage-7.14.3-py3-none-any.whl", hash = "sha256:fb7e18afb6e903c1a92401a2f0501ac277dca527bb9ca6fe1f691a8a0026a0e8", size = 212469, upload-time = "2026-06-22T23:10:23.405Z" },
 ]
 
 [[package]]
@@ -543,11 +531,11 @@ wheels = [
 
 [[package]]
 name = "deepmerge"
-version = "2.0"
+version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a8/3a/b0ba594708f1ad0bc735884b3ad854d3ca3bdc1d741e56e40bbda6263499/deepmerge-2.0.tar.gz", hash = "sha256:5c3d86081fbebd04dd5de03626a0607b809a98fb6ccba5770b62466fe940ff20", size = 19890, upload-time = "2024-08-30T05:31:50.308Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2a/78/6e9e20106224083cfb817d2d3c26e80e72258d617b616721a169b87081e0/deepmerge-2.1.0.tar.gz", hash = "sha256:07ca7a7b8935df596c512fa8161877c0487ac61f691c07766e7d71d2b23bdd2f", size = 21449, upload-time = "2026-06-22T05:46:07.669Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2d/82/e5d2c1c67d19841e9edc74954c827444ae826978499bde3dfc1d007c8c11/deepmerge-2.0-py3-none-any.whl", hash = "sha256:6de9ce507115cff0bed95ff0ce9ecc31088ef50cbdf09bc90a09349a318b3d00", size = 13475, upload-time = "2024-08-30T05:31:48.659Z" },
+    { url = "https://files.pythonhosted.org/packages/51/25/2a75b47cb057b1e164c604fb81ab690a6cdb5e2260ce651194eae90f64a3/deepmerge-2.1.0-py3-none-any.whl", hash = "sha256:8f148339a91d680a75ecb74ade235d9e759a93df373a0b04e9d31c8666cfeb75", size = 14345, upload-time = "2026-06-22T05:46:06.742Z" },
 ]
 
 [[package]]
@@ -584,7 +572,7 @@ wheels = [
 
 [[package]]
 name = "fastapi"
-version = "0.137.1"
+version = "0.138.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -593,9 +581,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d5/b1/e5b92c59d2c37817e77c1a8c2fc1f79cdcc04c68253e5406b43e3204cba7/fastapi-0.137.1.tar.gz", hash = "sha256:822360704230d9533d8d9475399613525968aa2f0b5bd2a3ccc9f18c88fd541c", size = 408293, upload-time = "2026-06-15T11:28:20.79Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/58/ff455d9fe47c60abadb34b9e05a304b1f05f5ab8000ac01565156b6f5e43/fastapi-0.138.0.tar.gz", hash = "sha256:d445a4877636ad191e7053e08c9bf98cb921a6756776848400bb773d1740c061", size = 419240, upload-time = "2026-06-20T01:18:05.259Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/da/35/380b9a5922f4340e51c309cde09e5bd32e62f02302971bee30dc15aa0624/fastapi-0.137.1-py3-none-any.whl", hash = "sha256:64f6983c59e45c4b9fdc44e57cb8035c2451ee91ea8e8ec042aca37de7cf6b69", size = 121877, upload-time = "2026-06-15T11:28:19.523Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/ff/8496d9847a5fedae775eb49460722d3efaa80487854273e9647ae876218c/fastapi-0.138.0-py3-none-any.whl", hash = "sha256:b6f54fd1bd72c80b0f899f172c61a600f6f7af9b43d4d772a018f35624048cb0", size = 126779, upload-time = "2026-06-20T01:18:03.483Z" },
 ]
 
 [[package]]
@@ -1003,7 +991,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.27.2"
+version = "1.28.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1021,9 +1009,9 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/27/3c/347cf965d313f5d41764e7d46bea6ffe7d9ef13b983cc429b0340962a082/mcp-1.27.2.tar.gz", hash = "sha256:8e02db104096d1c25b28e64bde29a5c32b31bc241710213e12fd4d84985bdfef", size = 621116, upload-time = "2026-05-29T17:16:04.039Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c1/ee/94c6c50ffc5b5cf4737052275d11b57367f32d1a8516e31dcd60591b3916/mcp-1.28.0.tar.gz", hash = "sha256:559d3f9943674cafbe5744c5d3794f3237e8b47f9bbc58e20c0fad680d8487c2", size = 636040, upload-time = "2026-06-16T21:37:17.996Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c9/11/252c6f971dc4f16af1d98a1c469d8ba523aab00d1bb76b4d3bc1ff32eacc/mcp-1.27.2-py3-none-any.whl", hash = "sha256:d6ff5160c6ca65d93013626efb3fc249de683c30b2d8570755ceddd490344de5", size = 220498, upload-time = "2026-05-29T17:16:02.442Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/e1/4c1dc1fbb688641a712d34650c3d58bbbdcb314ddb75bc5817bbf33515a4/mcp-1.28.0-py3-none-any.whl", hash = "sha256:9c1e7cf3a9125557e418ecd4fed8e9adddce81b0dfdae4d6601d700f5beb71a4", size = 221959, upload-time = "2026-06-16T21:37:16.579Z" },
 ]
 
 [[package]]
@@ -1524,28 +1512,28 @@ wheels = [
 
 [[package]]
 name = "pydantic-settings"
-version = "2.14.1"
+version = "2.14.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/07/60/1d1e59c9c90d54591469ada7d268251f71c24bdb765f1a8a832cee8c6653/pydantic_settings-2.14.1.tar.gz", hash = "sha256:e874d3bec7e787b0c9958277956ed9b4dd5de6a80e162188fdaff7c5e26fd5fa", size = 235551, upload-time = "2026-05-08T13:40:06.542Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ae/8d/f1af3832f5e6eb13ba94ee809e72b8ecb5eef226d27ee0bef7d963d943c7/pydantic_settings-2.14.1-py3-none-any.whl", hash = "sha256:6e3c7edfd8277687cdc598f56e5cff0e9bfff0910a3749deaa8d4401c3a2b9de", size = 60964, upload-time = "2026-05-08T13:40:04.958Z" },
+    { url = "https://files.pythonhosted.org/packages/77/c1/6e422f34e569cf8e18df68d1939c81c099d2b61e4f7d9621c8a77560799c/pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440", size = 61715, upload-time = "2026-06-19T13:44:55.02Z" },
 ]
 
 [[package]]
 name = "pygal"
-version = "3.1.0"
+version = "3.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "importlib-metadata" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b0/b6/04176faeb312c84d7f9bc1a810f96ee38d15597e226bb9bda59f3a5cb122/pygal-3.1.0.tar.gz", hash = "sha256:fbdee7351a7423e7907fb8a9c3b77305f6b5678cb2e6fd0db36a8825e42955ec", size = 81006, upload-time = "2025-12-09T10:29:19.587Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/dd/b9/58bbfa4d0e2672b0f0baf84047b17d58fda0d9351427e2b6784899924a1b/pygal-3.1.3.tar.gz", hash = "sha256:dd119c14cdeb56beb85282e3e2687ece30561225d410a822e6bb68699aa6e7b1", size = 80887, upload-time = "2026-06-18T20:44:51.368Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/4c/2862dd25352fe4b22ec7760d4fa12cb692587cd7ec3e378cbf644fc0d2a8/pygal-3.1.0-py3-none-any.whl", hash = "sha256:4e923490f3490c90c481f4535fa3adcda20ff374257ab9d8ae897f91b632c0bb", size = 130171, upload-time = "2025-12-09T10:29:16.721Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/43/5441ea0f9a35a0f2d30a79712cc21c737cf959a3451565d41e09d2fd90de/pygal-3.1.3-py3-none-any.whl", hash = "sha256:c0b9bc2d31df4094c9f65b0969b62571a47b28197aced081b1a9433c3a760f32", size = 132630, upload-time = "2026-06-18T20:44:49.643Z" },
 ]
 
 [[package]]
@@ -1573,15 +1561,15 @@ crypto = [
 
 [[package]]
 name = "pymdown-extensions"
-version = "10.21.3"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9e/26/d1015444da4d952a1ca487a236b522eb979766f0295a0bd0c5fc089989a9/pymdown_extensions-10.21.3.tar.gz", hash = "sha256:72cfcf55f07aea0d4af2c4f11dd4e52466ddfb1bb819673146398e0bd3a77354", size = 854140, upload-time = "2026-05-13T12:57:32.267Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/67/f1e79672a5f91985577c7984c9709ca110e4fd37fe7fd167b60422e6ccc2/pymdown_extensions-11.0.tar.gz", hash = "sha256:8269cef0247f9e2d0a62fcea10860aba05c1cbab5470fd4b63230b96434dc589", size = 857049, upload-time = "2026-06-23T02:27:45.146Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/85/545a951eecc270fcd688288c600017e2050a1aacb56c711d208586d3e470/pymdown_extensions-10.21.3-py3-none-any.whl", hash = "sha256:d7a5d08014fc571e80ca21dd6f854e31f94c489800350564d55d15b3c41e76b6", size = 269002, upload-time = "2026-05-13T12:57:30.296Z" },
+    { url = "https://files.pythonhosted.org/packages/af/b6/1ae53367e28b9cffa3be7574e13fbe4589694272fd47710fbdbafd3d63c6/pymdown_extensions-11.0-py3-none-any.whl", hash = "sha256:fbc4acb641814fa9d17521bbd21a5240ef739a662f11c06330c4b78c93e954d6", size = 269415, upload-time = "2026-06-23T02:27:43.826Z" },
 ]
 
 [[package]]
@@ -1631,7 +1619,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.1.0"
+version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -1640,9 +1628,9 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/84/0e/b5858858d74958632c49b72cb25a3976ff9f632397626715be71c89d3971/pytest-9.1.0.tar.gz", hash = "sha256:41dd9148c08072446394cefd3d79701701335a9f4cae69ba92e39f6c7f5c061c", size = 1634181, upload-time = "2026-06-13T18:52:45.983Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8b/5a/ba30a81239b909821b3153e303e7def45178bf353da4f72380e6c5e8793b/pytest-9.1.0-py3-none-any.whl", hash = "sha256:8ebb0e7888bdf2bdfc602ec51f8f62d50200af37356c74e503c79a94f5c81f32", size = 386453, upload-time = "2026-06-13T18:52:44.045Z" },
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]
@@ -1760,7 +1748,7 @@ requires-dist = [
     { name = "click", marker = "extra == 'click'", specifier = ">=8.4.1" },
     { name = "docker", specifier = ">=7.1.0" },
     { name = "emoji", specifier = ">=2.15.0" },
-    { name = "fastapi", specifier = ">=0.137.1" },
+    { name = "fastapi", specifier = ">=0.138.0" },
     { name = "humanize", specifier = ">=4.15.0" },
     { name = "influxdb-client", specifier = ">=1.50.0" },
     { name = "jinja2", specifier = ">=3.1.6" },
@@ -1768,7 +1756,7 @@ requires-dist = [
     { name = "packaging", specifier = ">=26.2" },
     { name = "psutil", specifier = ">=7.2.2" },
     { name = "pydantic", specifier = ">=2.13.3" },
-    { name = "pydantic-settings", specifier = ">=2.14.0" },
+    { name = "pydantic-settings", specifier = ">=2.14.2" },
     { name = "pygal", specifier = ">=3.1.0" },
     { name = "pyotp", specifier = ">=2.10.0" },
     { name = "pyoutlineapi", marker = "extra == 'pyoutlineapi'", specifier = ">=0.4.0" },
@@ -1786,14 +1774,14 @@ dev = [
     { name = "codeclone", extras = ["mcp"], specifier = ">=2.0.2" },
     { name = "mypy", specifier = ">=2.1.0,<3" },
     { name = "pre-commit", specifier = ">=4.6.0" },
-    { name = "pytest", specifier = ">=9.1.0,<10" },
+    { name = "pytest", specifier = ">=9.1.1,<10" },
     { name = "pytest-cov", specifier = ">=7.1.0,<8" },
-    { name = "ruff", specifier = ">=0.15.17,<0.16" },
+    { name = "ruff", specifier = ">=0.15.19,<0.16" },
     { name = "types-cachetools", specifier = ">=7.0.0.20260503,<8" },
     { name = "types-python-dateutil", specifier = ">=2.9.0.20260508,<3" },
     { name = "types-pyyaml", specifier = ">=6.0.12.20260510,<7" },
     { name = "types-requests", specifier = ">=2.33.0.20260513,<3" },
-    { name = "zensical", specifier = ">=0.0.45" },
+    { name = "zensical", specifier = ">=0.0.46" },
 ]
 
 [[package]]
@@ -2039,27 +2027,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.17"
+version = "0.15.19"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8c/a9/3abdf488f1bf3d24c699415e454ed554a6350d5d89ce183be1ee0a3361ac/ruff-0.15.17.tar.gz", hash = "sha256:2ec446937fd16c8c4de2674a209cc5af64d9c6f17d21fbf1151054fa0bcf5219", size = 4743346, upload-time = "2026-06-11T17:54:47.663Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d5/e6/15800dfde183a1a106594016c912b4c12d050a301989d1aca6cb63759fe8/ruff-0.15.19.tar.gz", hash = "sha256:edc27f7172a93b32b102687009d6a588508815072141543ae603a8b9b0823063", size = 4772071, upload-time = "2026-06-24T01:10:46.942Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/db/4d/e11259f5da07cb6afb2d074c31bf09da9671993f7329d4f15d2fdc458301/ruff-0.15.17-py3-none-linux_armv6l.whl", hash = "sha256:d9feddb927fc68bd295f5eebc587a7e42cfaf9b65f60ca4a2386febff575da8f", size = 10856677, upload-time = "2026-06-11T17:54:49.533Z" },
-    { url = "https://files.pythonhosted.org/packages/29/3e/772d679e1a0dc058e58875bd2c0cb713a0530877b4a76fee3c7966df0d49/ruff-0.15.17-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:25805a226d741c47d274a35ad5c10a7dde175fcddfa511d7cf3da0a21eb3eab7", size = 11223443, upload-time = "2026-06-11T17:55:00.573Z" },
-    { url = "https://files.pythonhosted.org/packages/68/58/bd41f7688b2fd5623012605130ed70e60aa7f2244baa3d5066bdd61530c8/ruff-0.15.17-py3-none-macosx_11_0_arm64.whl", hash = "sha256:f6ad73b14c2d18a3bf8ad7cb6974294d7f613a7898604826058e6ac64918ef4d", size = 10566458, upload-time = "2026-06-11T17:55:07.52Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/5b/733371013fcf1ec339e477ece6ab42bfe10bdd9bba8ee88a9516aa56bfc0/ruff-0.15.17-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6ba0c1e4f95bcb3869d0d30cbd5917071ef2e28665abfec970cdab0492c713ed", size = 10914483, upload-time = "2026-06-11T17:55:05.501Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/cc/6f24251cc0252f7239391ccb85833f320efad14ebe5b443943f37ced6332/ruff-0.15.17-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:81647960f10bff57d2e51cadd0c3950fe598400c852863a038720ef5b8cca91e", size = 10647497, upload-time = "2026-06-11T17:54:57.733Z" },
-    { url = "https://files.pythonhosted.org/packages/68/dd/0d10c17ce1a1624d6fc3156309c3f834fdb5dfaad026ec90c85684f3990e/ruff-0.15.17-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0e01a84ddbc8c16c23055ba3924476850f1bbc1917cebbb9376665a63e74260d", size = 11416967, upload-time = "2026-06-11T17:54:51.461Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/91/556bfb156f6144f355e831c23db00b2fc4120f86b3ce81cc5f7fd2df51f3/ruff-0.15.17-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:84fe9f653152f8f294f9f7e03bf3a453d8b4a27f7a59c78c8666167f2b17b96c", size = 12335770, upload-time = "2026-06-11T17:54:45.793Z" },
-    { url = "https://files.pythonhosted.org/packages/88/82/8b5999aa13355e926f06d9f42a32dcca862f623bf0363785ff89d607dffd/ruff-0.15.17-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8c0fe88a7676e7a05b73174d4d4a59cb2ac21ff8263583f87a81a6018475a978", size = 11575441, upload-time = "2026-06-11T17:54:32.661Z" },
-    { url = "https://files.pythonhosted.org/packages/11/93/f10377bb04109ca0e8cbc483ff1982c54b6d418210041776f93e8cdc7fa9/ruff-0.15.17-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ecfc3c7878fff94633ab0348524e093f9ce3243080416dd7d14f8ba400174719", size = 11557614, upload-time = "2026-06-11T17:54:34.698Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/a6/eeeae7f7d5493df41649ab3db92f086b2d0a30199e4efdf8e3dd7a033f24/ruff-0.15.17-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:b8461180b22420b1bdc289909410930761629fddf2a5aaf60fae1ab26cedc4c4", size = 11544450, upload-time = "2026-06-11T17:54:39.042Z" },
-    { url = "https://files.pythonhosted.org/packages/32/88/5991ce565129a24dd4a00db1254b3b5db2e53018cbe4018ea5a89738e727/ruff-0.15.17-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:6eccbe50a038b503e7140b441aa9c7fc8c1f36edf23ebef9f4165c2f28f568b7", size = 10892524, upload-time = "2026-06-11T17:55:09.432Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/1d/0fdd248313425f55223968af04b0a42125466a8d88d21c1d99c6af0a51e8/ruff-0.15.17-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:382fc0521025f5a8ad447d8bdd523545d0d7646adb718eb1c2dac5065ec27c0f", size = 10659573, upload-time = "2026-06-11T17:54:36.824Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/0e/072e8260deb9461062ce9311ced27a8e541229a6ffd483013dd37661e43e/ruff-0.15.17-py3-none-musllinux_1_2_i686.whl", hash = "sha256:456d41fcd1b2777ad63f09a6e7121d43f7b688bbc76a800c10f7f8fb1f912c3f", size = 11127818, upload-time = "2026-06-11T17:55:03.124Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/b4/55060a34163121498014696b5f656db5b8c6963768f227dbf0d76b311073/ruff-0.15.17-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:b1a04bcc94ae6194e9db05d16ad31f298a7194bfbcb08258bbe589cee1d587b8", size = 11655901, upload-time = "2026-06-11T17:54:53.562Z" },
-    { url = "https://files.pythonhosted.org/packages/49/71/9b29d6b87cef468d697f43c6a91e3fae4a80185779d7d5a4ef27d173439f/ruff-0.15.17-py3-none-win32.whl", hash = "sha256:596065960ab1ff593f744220c9fe6580eda00a95003cffa9f4048bb5b1bf0392", size = 10925574, upload-time = "2026-06-11T17:54:55.723Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/b2/8fc77f3723228836fa5d12497eb71c808f83782e10d058d2b15cfa14640b/ruff-0.15.17-py3-none-win_amd64.whl", hash = "sha256:6769e5fa1710b179b92e0bfa5a51735b35baea9013dadb06d5f44cbcf9547084", size = 12058788, upload-time = "2026-06-11T17:54:41.042Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/c7/c53e8dbff9c9dc4b7928773421ae294a5d28fcb8dcda1a089579d3a7e510/ruff-0.15.17-py3-none-win_arm64.whl", hash = "sha256:f3be1fbb34bcdfd146240d8fb92a709d4c2c8191348580a3c044ec60fa0b4456", size = 11355275, upload-time = "2026-06-11T17:54:43.635Z" },
+    { url = "https://files.pythonhosted.org/packages/88/4c/9ded7626c39a0440c575bf69e2bf500d443388272c842662c59852ee7fcd/ruff-0.15.19-py3-none-linux_armv6l.whl", hash = "sha256:922d1eb283161564759bd49f507e91dc6112c15da8bd5b84ed714e086243cf86", size = 10950859, upload-time = "2026-06-24T01:10:38.491Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/ef/c211505ece1d00ef493d58e54e3b6383c946a21e9874774eb531f2512cf3/ruff-0.15.19-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:4d190d8f62a0b94aba8f721116538a9ee29b1e74d26650846ba9b99f0ae21c40", size = 11294529, upload-time = "2026-06-24T01:10:36.481Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/93/78d462e7d39968e58094dc57be7d09ffb14ce37da5b68ed70338a35a1f21/ruff-0.15.19-py3-none-macosx_11_0_arm64.whl", hash = "sha256:5a2c86ba6870dd415a9d9eb8be94d7924ebec6a26ffc7958ec7ca29d4bff967d", size = 10641416, upload-time = "2026-06-24T01:10:48.923Z" },
+    { url = "https://files.pythonhosted.org/packages/76/c4/5cb66cfd1f865d5cca908b86c93ac785e7f572193d3c7426079ca6643e24/ruff-0.15.19-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:82b432bc087264aea70fd25ac198918b70bd9e2aa0db4297b0bb91bbfbbc63ce", size = 11015582, upload-time = "2026-06-24T01:10:30.089Z" },
+    { url = "https://files.pythonhosted.org/packages/51/9f/8ecfaec10cf5eecd28fbc00ff4fb867db90a1be54bf3d39ebf93f893cd52/ruff-0.15.19-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8530a09d03b3a8c994f8b559a7dcdabc690bcd3f78ef276c38c83166798ebf56", size = 10744059, upload-time = "2026-06-24T01:10:32.48Z" },
+    { url = "https://files.pythonhosted.org/packages/35/6b/983249d04562bc2d590edd75f32455cdb473affb3ba4bc8d883e939c697d/ruff-0.15.19-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:87bf21fb3875fe69f0eacc825411657e2e85589cce633c35c0adf1113649c62b", size = 11568461, upload-time = "2026-06-24T01:10:17.435Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/39/bc7794f127b18f492a3b4ee82bba5a900c985ff13b72b46f46e3c171ba34/ruff-0.15.19-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f9b229cb3ef56ecc2c1c8ebeca64b7a7740ccaef40a9eb097e78dde5a8560b83", size = 12429690, upload-time = "2026-06-24T01:10:40.638Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/3b/0de6859e698ed11c8a49e765196c8d333599b6a546c0715df39b6ba1aa2e/ruff-0.15.19-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c6c754515be7b76afe6e7e62df7776709571bcfc1631183828afcf3bafa869e3", size = 11693067, upload-time = "2026-06-24T01:10:25.681Z" },
+    { url = "https://files.pythonhosted.org/packages/89/3d/0b1f30f84bee9ae6ae8d349c2ba8b6f4b040966744efdd3acc804ae7c024/ruff-0.15.19-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6a498f82e0f4d8904c4e0aea5139cdfac1f39d19a3c51d491292f63a36e83b2e", size = 11616911, upload-time = "2026-06-24T01:10:44.809Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/eb/c90bd3dfc12eed9032c2c1bfe05105b93a1b2c8bce555db6308315b853ce/ruff-0.15.19-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:d48caa34488fb521fd0ef4aea2b0e8fe758298df044138f0d67b687a6a0d07ed", size = 11649343, upload-time = "2026-06-24T01:10:23.472Z" },
+    { url = "https://files.pythonhosted.org/packages/82/91/01caa13602a2f12fae5edbe8caf78b3c1e6db1293132aee6959eecce095c/ruff-0.15.19-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:4171b6613effa9363cd46dd4f75bd1827b6d1b946b5e278ed0c600d305379445", size = 10977610, upload-time = "2026-06-24T01:10:50.892Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/51/acb817922feab9ecbb3201377d4dbe7a25f1395e46545820061973f03468/ruff-0.15.19-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:27c15b2a241dd4d995557949a094fe78b8ad99122a38ccae1595849bcc947b3f", size = 10744900, upload-time = "2026-06-24T01:10:42.726Z" },
+    { url = "https://files.pythonhosted.org/packages/84/bc/5c8ca46b8a7a3f2b16cfbec88721d772b1c93912904e8f8c2e49470fea63/ruff-0.15.19-py3-none-musllinux_1_2_i686.whl", hash = "sha256:ed03b7862d68f0a8771d50ee129980cbf1b113f96e250b73954bc292f689e0bb", size = 11293560, upload-time = "2026-06-24T01:10:21.262Z" },
+    { url = "https://files.pythonhosted.org/packages/81/e0/4a888cbe4d5523b3f77a2b1fa043f46cfeba1b32eac35dcfadee0578fa8a/ruff-0.15.19-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:08143f0685ae278b30727ea72e90c61e5bd9c31b91aac4f5bb989538f73d24b8", size = 11696533, upload-time = "2026-06-24T01:10:53.046Z" },
+    { url = "https://files.pythonhosted.org/packages/98/43/c34b2fcd79262a85161764a97aaca89c3e4f574340ab61430cefa2bdd2c1/ruff-0.15.19-py3-none-win32.whl", hash = "sha256:8f47f0f92952af2557212bb10cf3e695cd4cf28b2c6e42cdb18ec6c9ebfa19da", size = 10986299, upload-time = "2026-06-24T01:10:55.185Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e8/15fd23e02b2442b56b2026b455977bc3057aa34b26e6323d1e99e8531a9f/ruff-0.15.19-py3-none-win_amd64.whl", hash = "sha256:efeca47ee3f9d4a7162655a3b8e6ee4a878646044233978d4d2c1ff8cdd914f0", size = 12123473, upload-time = "2026-06-24T01:10:27.74Z" },
+    { url = "https://files.pythonhosted.org/packages/30/66/9a73695e31eaee04f35d8475998bf8ab354465f9c638936d76111603dcc5/ruff-0.15.19-py3-none-win_arm64.whl", hash = "sha256:6c6b607466e47349332eb1d9be52fb1467423fc07c217341af41cd0f3f0573be", size = 11376779, upload-time = "2026-06-24T01:10:34.465Z" },
 ]
 
 [[package]]
@@ -2073,15 +2061,15 @@ wheels = [
 
 [[package]]
 name = "sse-starlette"
-version = "3.4.4"
+version = "3.4.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "starlette" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f7/2b/58abc2d1fd397e7dde08e947e05c884d8ef2f78d5e2588c17a12d42d6994/sse_starlette-3.4.4.tar.gz", hash = "sha256:07e0fa0460138baf25cdd5fb28683472c3995dc1642225191b3832d62526bcb0", size = 31819, upload-time = "2026-05-12T17:37:17.019Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d2/1b/bc9e3e7a72dcdad7dc7888758f5d00f56f8909ed5cfdff822bd72bb4c520/sse_starlette-3.4.5.tar.gz", hash = "sha256:83072538bc211a2f68b7b0422226c4af3e9b62e106e07034664b832ca019842a", size = 35249, upload-time = "2026-06-20T17:36:58.322Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/dc/67/805710444ea8cc75fbf70b920ed431a560c4bf9c57f7d5a3117213189399/sse_starlette-3.4.4-py3-none-any.whl", hash = "sha256:3f4dd50d8aed2771a091f3a83000323fc3844541c16b4fe585ae2420cc6df973", size = 16514, upload-time = "2026-05-12T17:37:15.601Z" },
+    { url = "https://files.pythonhosted.org/packages/78/75/c88d3f5dafd59c791da1ce27650d30bf5b70cbf1cbf01cd00e5f9e360915/sse_starlette-3.4.5-py3-none-any.whl", hash = "sha256:e71bad53323f65573c3864a6c3bd0c1eb6e5f092b2e48082b0c35927d19ca296", size = 16518, upload-time = "2026-06-20T17:36:56.729Z" },
 ]
 
 [[package]]
@@ -2226,7 +2214,7 @@ wheels = [
 
 [[package]]
 name = "virtualenv"
-version = "21.5.0"
+version = "21.5.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "distlib" },
@@ -2234,9 +2222,9 @@ dependencies = [
     { name = "platformdirs" },
     { name = "python-discovery" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/cd/0e/933bacb37b57ae7928b0030eef205a3dbb3e37afdbdde5be2e113318958f/virtualenv-21.5.0.tar.gz", hash = "sha256:98847aadf5e2037e0e4d2e19528eb3aca6f23906422e59a510bff231a6d32fce", size = 4577424, upload-time = "2026-06-13T20:36:45.066Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f1/a5/81f987504738e6defeed61ec1c47e2aefab3c35d8eeb87e1b3f38cf28254/virtualenv-21.5.1.tar.gz", hash = "sha256:dca3bf98275a59c652b69d68e73433e597d977c2da9198882479d1a7188009c8", size = 4578798, upload-time = "2026-06-16T16:23:58.603Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/87/b0667ede418386ab631e48924b845d326f366d61e6bd08fe68a748fae4d4/virtualenv-21.5.0-py3-none-any.whl", hash = "sha256:8f7c38605023688c89789f566959006af6d61c99eeeb9e58342eb780c5761e5e", size = 4557937, upload-time = "2026-06-13T20:36:42.967Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/02/3623e6169bed617ed1e2d372f7c69f92ec28d54c4dfc997055c8578ec148/virtualenv-21.5.1-py3-none-any.whl", hash = "sha256:55aa670b67bbfb991b03fda39bd3276d92c419d702376e98c5df1c9989a26783", size = 4558820, upload-time = "2026-06-16T16:23:56.963Z" },
 ]
 
 [[package]]
@@ -2332,7 +2320,7 @@ wheels = [
 
 [[package]]
 name = "zensical"
-version = "0.0.45"
+version = "0.0.46"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -2344,20 +2332,20 @@ dependencies = [
     { name = "pyyaml" },
     { name = "tomli" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f3/d1/ecb1889fd2208b2d577e6ff952d9bee201302eec7966b5b61cc64adfd8f5/zensical-0.0.45.tar.gz", hash = "sha256:315bce4ab0470338dd3588add38fb325f840856c375722e6802bd58a06446266", size = 3935947, upload-time = "2026-06-09T11:23:32.349Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/57/c7bbb71f943e1e0ba5ce460f4930ec836ead7286969e7fd742f7a6c049ab/zensical-0.0.46.tar.gz", hash = "sha256:3ec21f4fb1e78cd7c0d6b07ae336b04770e27ba020dabc457b2790e5d34f1978", size = 3973968, upload-time = "2026-06-21T18:52:40.368Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ad/fd/6b84115e3bbe6b76ebb1265e8ff2161c0bc88dcd6499eaf29c61a66421e9/zensical-0.0.45-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:c4cb2e11132f02ae824e246e016e073458e12e9de1eaf86fd39f01890d41204c", size = 12698844, upload-time = "2026-06-09T11:22:56.537Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/dc/4ddf05d77c1455c32cb26da71f2a19d355927a45a3db5b26fb258a07ce8f/zensical-0.0.45-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:799a01de2102b5f731744ad31bdbc464d0c07d484e67ba148f6923679afa6ce6", size = 12571590, upload-time = "2026-06-09T11:23:00.192Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/53/60c6cc7b2ce8b1a83eb87bff3f7289447995552fd9a30ca76ffba22ca9d5/zensical-0.0.45-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6201e79ea8a64bd3ced3f05ef4b1529da0e675d67b1395987c0ba942e4e10dc4", size = 12939590, upload-time = "2026-06-09T11:23:02.721Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/1e/e9217ed75dba323a6f9a4eee28eb40416eff99932cd0ee6c394bf07b9ead/zensical-0.0.45-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:854aaf500e4a3ce64adea1faa7a1820c7cf9a4f66be1043e4e9ba727fe9cf2b5", size = 12911669, upload-time = "2026-06-09T11:23:05.407Z" },
-    { url = "https://files.pythonhosted.org/packages/71/3c/6fc9fe2334bb4460a8a8d732e23a30d2ddc2ecf63c2eb3487d9e7405e70d/zensical-0.0.45-cp310-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a80c57fd50fc60415914388286ac10a7d8b6f70b8ca7235597d09fb12c3171b0", size = 13267643, upload-time = "2026-06-09T11:23:07.915Z" },
-    { url = "https://files.pythonhosted.org/packages/be/f9/5696114af4ede5f1bd01e641a4ff24ee8ca49810bfaa28e5be12d930c0ef/zensical-0.0.45-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58c3510f69e08b6ed8bb9596fc9393e4687f90394aa0ef2d6118b1375ad97be5", size = 12972147, upload-time = "2026-06-09T11:23:12.069Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/9e/5c6acde480c43f8c993b13260925df8db31d51ab8a9977618e9efdd98d45/zensical-0.0.45-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:01c484bb2ee85e98e21e24b397ff52ffc31101f7485935eee5d3afa6cca6cc08", size = 13117360, upload-time = "2026-06-09T11:23:15.155Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/31/ea21f102049b35a8fe5218c5331857a15eeb60deb1bb21823a4c0701e274/zensical-0.0.45-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:3654b708830303759e866a58a60c483cd2a1c56a44acdaae5bbb341a3f40ebce", size = 13185593, upload-time = "2026-06-09T11:23:18.166Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/97/6ded39fe27fa8a292d17d9af713b018e4919315233b60fa4b4b0aca737a6/zensical-0.0.45-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:c4da1c37eca1474b487def0ef40d7ac2aff31a9d7a029cb7479ef7c354437361", size = 13326882, upload-time = "2026-06-09T11:23:21.027Z" },
-    { url = "https://files.pythonhosted.org/packages/79/80/075975032a9e20f319c0134f8ca659d295ee4908f15ab212702a2728247f/zensical-0.0.45-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:f8a1966c186feebd3b795f9d420000bfd582e16eefdd9bc7a286d878faabae52", size = 13253961, upload-time = "2026-06-09T11:23:23.99Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/6a/0eab0eb311af6a07cde15ca58d5d720cbfa02cd509e4c7fb5fa20cda0b46/zensical-0.0.45-cp310-abi3-win32.whl", hash = "sha256:a1dd63a5efb8d0e5f2fadf862f02771a279dc5cbe9a982700194650065758f01", size = 12257083, upload-time = "2026-06-09T11:23:26.769Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/cd/b117e749c60b1d1e16b8450db1355f69f38376f783b8c6c8815202988933/zensical-0.0.45-cp310-abi3-win_amd64.whl", hash = "sha256:1f2c0e69839ce4274bde34d18139d3b0d96bbf02b245ada46243590c9eedebc1", size = 12498335, upload-time = "2026-06-09T11:23:29.702Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/bd/bbc499ee35ac9ec5459dbfec7bb7231556689e97eaa13a5eddbe1f0443b5/zensical-0.0.46-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:d91af81ab058c8693dfd75f2f77b4c73bcba4125681d1d276f38624291820bd2", size = 12796482, upload-time = "2026-06-21T18:52:07.369Z" },
+    { url = "https://files.pythonhosted.org/packages/88/1b/7acc273184d59b8e894d15ebe3cf1c5e81b3a822fde1792ea3e33be37a2e/zensical-0.0.46-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:d9221264a9a87409900a47e29985607b0c9245dacb89077e87c8e16e31edc167", size = 12660030, upload-time = "2026-06-21T18:52:10.186Z" },
+    { url = "https://files.pythonhosted.org/packages/80/df/bd0a68de98a19fc6050c58be11f36d05ea72a213b6a7ff7395d33c793747/zensical-0.0.46-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ec43018d5343ca2e1d71aa352eeddd560fef504effd03025840a5a783abefa4f", size = 13057130, upload-time = "2026-06-21T18:52:12.911Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/db/e27635f5787a42245f900e658340698a6654e165d466f9a3b640efced2cd/zensical-0.0.46-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:26e98fb8ab7ab50cdd20a73e2c7d4d9aae0b46cf2d8691e6bb22f9c261b8a60a", size = 13022345, upload-time = "2026-06-21T18:52:15.84Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/9d/6ce2ba11c97154870b458a8dae4637ade93b7097912f0102f5ea7fe8cf5b/zensical-0.0.46-cp310-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:46fe578f26963f8ee89567983e62737b6fadc9197d4742e1020b522e092d7baa", size = 13377445, upload-time = "2026-06-21T18:52:18.538Z" },
+    { url = "https://files.pythonhosted.org/packages/68/06/9930d43cd9d2f899b648d63491007c1b4f9716cf118b0c98e867b933069c/zensical-0.0.46-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:aef03fa186a5589148e10b62610500989c6b075a2c08e1554233adbf91b2a3dc", size = 13086749, upload-time = "2026-06-21T18:52:21.452Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/ed/2342cf860fbb02314938b0d1f1b02344935801b04d185ff3151ef1812898/zensical-0.0.46-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:bc7446cdf97a8dea390f20ed2bd6b030cddc1bd36a8ce113ea3efef6fa61c573", size = 13231120, upload-time = "2026-06-21T18:52:24.171Z" },
+    { url = "https://files.pythonhosted.org/packages/de/b0/d2ece02f63cd767fcf10fd7608dc8e0a995f87dc5261209b1dbc296fd57b/zensical-0.0.46-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:bbee37801f1ed500f158dc0992c569282950f780ae353c37fe6969f99983d701", size = 13295035, upload-time = "2026-06-21T18:52:26.942Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/b2/cb0048a612e63e615399fc507472a557d1c5b7c2f74065c5bf11998fd597/zensical-0.0.46-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:9487c147c9cceb50c04d0ad70b024821a6eab1629dafd70ab6d1e86ec841e623", size = 13437191, upload-time = "2026-06-21T18:52:29.69Z" },
+    { url = "https://files.pythonhosted.org/packages/91/16/515f81db8055b109a510063be481e60a657c4fad1a883680b2ee4aa9a424/zensical-0.0.46-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:f42a4683c762f026878d19ede4bcf7bfbb84dbecb5ad923949abb77806ed88a5", size = 13369382, upload-time = "2026-06-21T18:52:32.521Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/5c/da54ee65b642eb7d88dd4a3db35845d0765915638e05d5d434a10b42f1c3/zensical-0.0.46-cp310-abi3-win32.whl", hash = "sha256:85f018f2a7ee76a83915c87ddb12b58cf343fd6154081d33ac95b6751b011dd7", size = 12354298, upload-time = "2026-06-21T18:52:34.976Z" },
+    { url = "https://files.pythonhosted.org/packages/73/26/fc7ef081acbdada8436825221cb728ee84a81d4d78a7bb79aa58bd150d31/zensical-0.0.46-cp310-abi3-win_amd64.whl", hash = "sha256:1543a693a160de60e86ca589592401b584670e7e12c5ae30e3c2ba76786f7ec3", size = 12599687, upload-time = "2026-06-21T18:52:37.913Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1692,7 +1692,7 @@ wheels = [
 
 [[package]]
 name = "pytmbot"
-version = "0.4.0.dev0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },

--- a/uv.lock
+++ b/uv.lock
@@ -493,55 +493,52 @@ wheels = [
 
 [[package]]
 name = "cryptography"
-version = "48.0.1"
+version = "49.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/12/45/870e7f4bef50e5f53b9f51d4428aee5290eedf58ba443f16b1ebb7ab8e66/cryptography-48.0.1.tar.gz", hash = "sha256:266f4ee051abb2f725b74ef8072b521ce1feacf685a3364fa6a6b45548db791a", size = 832989, upload-time = "2026-06-09T22:32:31.8Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/99/d1c90d6041656cc6ee229dc99cd67fd0cd5aec3c5f7d72fffc27cc750054/cryptography-49.0.0.tar.gz", hash = "sha256:f89660a348f4f78a92366240a61404e337586ef7f5909a2fef59ca88ef505493", size = 854345, upload-time = "2026-06-12T20:02:30.512Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/bc/ee4137cbbe105652c0ee4252792b78fc8e7afa4b8e61d9d5dc05a7f45731/cryptography-48.0.1-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:3e4a1a3232eef2e6c732827d5722db29a0cc8b27af2a4d865b094cf954be9ca1", size = 8008324, upload-time = "2026-06-09T22:31:00.702Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/85/6379d42181bfc713094f081360fc5784d6c816b599d45e7f082502d173ce/cryptography-48.0.1-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:32143b24adb918f078134e1e230f1eb8cc04886b92c28b5f0041aaf3e5699225", size = 4696243, upload-time = "2026-06-09T22:32:33.446Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/87/c85d147b53323c7eb4d850920c8901377323c2a0ff8d79c262d4fee89aa2/cryptography-48.0.1-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f0d27a5696721ef7a672b8c810f6aded391058e0b9486e63e6d93baf765da691", size = 4713235, upload-time = "2026-06-09T22:31:40.141Z" },
-    { url = "https://files.pythonhosted.org/packages/79/58/67cbf8cf1ee7c54b439ca07bbecf8362c07afc11a3724fea70f745784add/cryptography-48.0.1-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:eb86ce1af36fe65041b6db9a8bb064ee621a7e5fded0f80d475ec243477cd242", size = 4702323, upload-time = "2026-06-09T22:31:42.191Z" },
-    { url = "https://files.pythonhosted.org/packages/89/c6/24266ac10c47f6cd2a865f4446062b466da1d1f10b27189eac00e61bf0c9/cryptography-48.0.1-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:b024e784ad6c077ee0147b35ea9cbfc1e34e1fd4c1dcca214c2794d73a12df08", size = 5300085, upload-time = "2026-06-09T22:31:58.703Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/bb/cc4b78784f97efc8c5874c2a9743708d172be6663024b34a0467885ae0c8/cryptography-48.0.1-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3752f2dbc8f07a30aad2932c986cea495b03bb554887828225da104f732852b6", size = 4746137, upload-time = "2026-06-09T22:31:31.01Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/52/0c44de3f5267f8fbe8e835138017522a333436166e406f0db9b9e6e3033f/cryptography-48.0.1-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:bd81490cd5801d755cf97bb68ac191f14b708470b1c7cf4580f669b9c9264cd8", size = 4333867, upload-time = "2026-06-09T22:32:28.096Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/2e/772d7adbfa931537bc401640b7cac9976bff689bda187833e5d63b428e49/cryptography-48.0.1-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:66fd0771e7b9c6dcd44cf1120690d2338d16d72795cf40cae2786a39eba65429", size = 4701805, upload-time = "2026-06-09T22:31:38.284Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/a3/b06844f303873493c963caf581c04df31c7035e0c1b0f02c4814d319ec80/cryptography-48.0.1-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:3fd2ca57062b241c856670b073487d2e86c4637937ca5601e48f97bf8e11fc8f", size = 5258461, upload-time = "2026-06-09T22:31:04.187Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/13/8b765e2e12b07c74941caadb9d1c8fdc006c4dfbf2b8f2d610519758954d/cryptography-48.0.1-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:0ee6ea481db1ab889cba043ec1eda17bb9c1ea79db6722f779c3667f9f70322f", size = 4745488, upload-time = "2026-06-09T22:32:30.07Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/aa/48972bce55049b32a94f4907eda4d75fa385aad8a39506cc2fc72196ecf0/cryptography-48.0.1-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:f2ceef93cb096aa3c4cc4b5c94ca6131f9196d28c64d6111533402a9b2054d41", size = 4830256, upload-time = "2026-06-09T22:31:43.868Z" },
-    { url = "https://files.pythonhosted.org/packages/47/a2/e5079a032fb85cf6005046ca92bbd78b0c82dad2b5751ab8c311659da06f/cryptography-48.0.1-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9bd3f92d76217892b15df84ca256c2c113d386fdda7a7d8691aeeced976507c6", size = 4979117, upload-time = "2026-06-09T22:31:05.845Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/a0/8f50cae9c74e718ed769d63ed5c74bd0ea830c9550a74629cebd1b9c7bc7/cryptography-48.0.1-cp311-abi3-win32.whl", hash = "sha256:b9a32b876490d66c8bcc9963ef220199569748434ab01a9d6aaeabf88e7f5158", size = 3304154, upload-time = "2026-06-09T22:32:16.845Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/69/0572c77dbace6fef72f33755bd52ea399c71367250d366237f8691826b9e/cryptography-48.0.1-cp311-abi3-win_amd64.whl", hash = "sha256:39489bfca54c7a1f6b297efcd8bc608ab92d16c4ca631b0cad4da46724588b24", size = 3817138, upload-time = "2026-06-09T22:32:00.388Z" },
-    { url = "https://files.pythonhosted.org/packages/42/06/3e768b4c3bc78201583fa35a0e18f640dd782ff41afba88f8545481a8874/cryptography-48.0.1-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:f817adc181390bd54f2f700107a7419040fb7c1bdf2fc26f36551a06a68c3345", size = 7989830, upload-time = "2026-06-09T22:31:07.8Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/13/6476736484b94041110c8340a3eb63962fea4975baea8cb4a512adb44d4d/cryptography-48.0.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d5d30989c6917b478b5817902e85fddaea2261efa8648383d965381ccb9e1ac4", size = 4689201, upload-time = "2026-06-09T22:31:09.745Z" },
-    { url = "https://files.pythonhosted.org/packages/79/62/65a87f34d2a431546e2509b85d55e8c90df86d668f6731da64d538512ac2/cryptography-48.0.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:df637c05205ea7c1d7fbcbe54bbfea648a52951155f997af13d895d0ecc96991", size = 4702822, upload-time = "2026-06-09T22:32:24.409Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/59/810b5204b0a9b10f4b6bc06bd551a8b609803cd931806bc3b71884b225e5/cryptography-48.0.1-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:869c3b8a53bfe27147832df48b32adadf558249d50e76cb3769d40e986b13265", size = 4694875, upload-time = "2026-06-09T22:32:08.737Z" },
-    { url = "https://files.pythonhosted.org/packages/24/dc/d8ca05ffea724eec6d232ea6f18e74c269eb6bdfdcc9bfba689790d1325f/cryptography-48.0.1-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:e361afba8918070d376df76f408a4f67fec0ee9cff81a99e48fe9a233ef59e17", size = 5290385, upload-time = "2026-06-09T22:31:15.212Z" },
-    { url = "https://files.pythonhosted.org/packages/03/8c/3be6cb4da181f5bb6c19cf560c2359d60644a6b5fc5b57854e528f47b296/cryptography-48.0.1-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:d069066deead00ac7f090be101be875a06855908f7ec004c27b8fefb4acfb411", size = 4737082, upload-time = "2026-06-09T22:32:22.66Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/f6/d5f60a5a1434dbfd949e227fd0065d194c7e6b6ac526b17f5c06152b8231/cryptography-48.0.1-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:09f73a725d582cef64b91281a322cd798d14a33b2b6f2b7ad9531dc336d84c02", size = 4325328, upload-time = "2026-06-09T22:32:10.777Z" },
-    { url = "https://files.pythonhosted.org/packages/17/b7/ba75dd947a14b6ad907b01ae8f6b5b348cdd1b48142f0063dee9e20c1d9d/cryptography-48.0.1-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:15254441469dd6bf027039453288e2072124f8b6603563f5d759e1c9b69273fa", size = 4694530, upload-time = "2026-06-09T22:31:53.105Z" },
-    { url = "https://files.pythonhosted.org/packages/62/29/50d6b9e8aff12d8b67afaeb3569335e32dc83a5723e3bbded24fdac9f809/cryptography-48.0.1-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:8ace4507d1e6533c125f4fac754f8bb8b6a74c08e92179dabd7e16571a3efbf3", size = 5245046, upload-time = "2026-06-09T22:31:25.774Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/04/618f4115cfc0add0838c82507aa18a346089428da8653ad38b3ff36f5cb3/cryptography-48.0.1-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:b4e391975f038e66432328639620a4aff2d307513b004f1ca06d6225bced815c", size = 4736660, upload-time = "2026-06-09T22:32:12.676Z" },
-    { url = "https://files.pythonhosted.org/packages/24/9c/06e062462a0de28a3b3911322eded4c16deb9f441b1b7575d3dc59488ab5/cryptography-48.0.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:42fcd8e26fe555d9b3577a135f5091fefa0aa4e99129c23fb56787a1bd4ada72", size = 4822229, upload-time = "2026-06-09T22:31:17.062Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/be/0561971eaaee4b8a0e7d5113c536921063ab91aaf23278ac374eaf881e11/cryptography-48.0.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:c1400da5e32a43253392277eac7490a60e497d810a63dd5608d71bbd7af507c9", size = 4966364, upload-time = "2026-06-09T22:31:32.842Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/27/728c77876f12b000820b69ae490f3c4083775e79e07827e9e60be07ad209/cryptography-48.0.1-cp314-cp314t-win32.whl", hash = "sha256:0df56b056bc17c1b7d6821dfa65216e62bd232d8ab05eb3db44e71d235651471", size = 3278498, upload-time = "2026-06-09T22:31:29.154Z" },
-    { url = "https://files.pythonhosted.org/packages/06/e3/79a612c6d7b1e6ee0edd43633d53035bec2cfb78c82b76f7864f39e36f34/cryptography-48.0.1-cp314-cp314t-win_amd64.whl", hash = "sha256:9de21387aa95e2a895823d0745b430bed4f33503ba9ab5e0b5311f33e37d66d2", size = 3798790, upload-time = "2026-06-09T22:31:56.697Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/6c/00fa2a95997164c8b2072ce327c23d4ab20809ccc323ea5fab91e53a4bba/cryptography-48.0.1-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:4fdc69f8e4316bcf0c8c8ec1f26f285d12e8142d88d96c876a59a03be3f6ae67", size = 7987408, upload-time = "2026-06-09T22:32:20.777Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/d9/45f309a7e4e5f3f8f121d6d3be9e94024a7726ec598d6e08ae04edb2f04d/cryptography-48.0.1-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:48fe40804d4caa2288f24e70ca8c64c42dd826da0ad7e4f1b41b2128d679e6c8", size = 4690196, upload-time = "2026-06-09T22:31:54.74Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/9f/a1bc8bcc798811b8527eb374bbccf30a3f3e806829d967118222bf1125eb/cryptography-48.0.1-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:86be3b1b0b6bf09482fb50a979c508d2950ed95f5621ec77f4e385962006b83a", size = 4696782, upload-time = "2026-06-09T22:31:45.615Z" },
-    { url = "https://files.pythonhosted.org/packages/66/c2/81a4fb4e4373c500bb526bc337ac5719dd31dd15b970b84a238168c6aa08/cryptography-48.0.1-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:4ab0a343c807bbcd90c971cd1ecf072937cd01847a9e002bef88fb47ac6be577", size = 4696618, upload-time = "2026-06-09T22:31:11.564Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/0b/aa68b221dde92d09cb29a024ede17550ee21e77a404e59fc093c82bb51e1/cryptography-48.0.1-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9621de99d2da096006b629979efd8ae7eb2d8b822488d0c89ee4000c306c59b1", size = 5289970, upload-time = "2026-06-09T22:31:20.368Z" },
-    { url = "https://files.pythonhosted.org/packages/78/13/fba657f958d2af66ea959a4ba01212632089249d34af1ae48054136344d7/cryptography-48.0.1-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:88c852a0ae366e262e5a1744b685e6a433dc8788dd2a277e418bf4904203609d", size = 4731873, upload-time = "2026-06-09T22:31:22.253Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/4c/9a964756d24a26b3e34dfcb16f961b89838786e6700b635b0d1e3adff4b6/cryptography-48.0.1-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:43c5835e2cb98c8733d86f57d6fc879b613f5c3478607281c3e36daffc6dd8a6", size = 4330804, upload-time = "2026-06-09T22:31:36.56Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/0f/a10f3a6eb12950a10e3a874070283aa2dd5875b2bfd15fad8a3e17b3f13e/cryptography-48.0.1-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:fe0180af5bf9236518a087e35bf2d9a347d5f5f51e63c579d683ddff424e3d46", size = 4696217, upload-time = "2026-06-09T22:31:13.351Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/6f/5cd12f951165ea73ef85266775d97e4c763b2474ccfd816dd69d3a18d6f8/cryptography-48.0.1-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:b7a2d1a937a738a881737cec135a38bb61470589b17515b9f73f571d0ae10401", size = 5245252, upload-time = "2026-06-09T22:32:02.193Z" },
-    { url = "https://files.pythonhosted.org/packages/68/ab/8aaa12e4516ec4464033ab79b6f3b592bd5a92102467c4ace8a0d970203f/cryptography-48.0.1-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:b74ca3b8e5ecdd833bf6a002ca41b4793bb27fb8f1c06ffaf2643c9e9140e31b", size = 4731388, upload-time = "2026-06-09T22:32:04.019Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/24/50027ea4dca85ec1f40688f3c24fb32ccacd520583c9592c3cc95628e6fb/cryptography-48.0.1-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:2c37f2461406063b417837f5f3daab668652acd82423efcd7f0a9f04be972de1", size = 4824186, upload-time = "2026-06-09T22:32:18.707Z" },
-    { url = "https://files.pythonhosted.org/packages/52/41/04cb5eb17085ade6f50cc611fb657df6a0f5885350de8764ece89c050197/cryptography-48.0.1-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:86fe77abb1bd87afb251d4d02ada7ecf53a32cee9b67d976abb2e45a13297475", size = 4964539, upload-time = "2026-06-09T22:31:18.793Z" },
-    { url = "https://files.pythonhosted.org/packages/36/bf/ed70785c496e89d7e73b7cda2d21f2447fd6d4e821714b8d04ff217fed92/cryptography-48.0.1-cp39-abi3-win32.whl", hash = "sha256:6b2c0c3e6ccf3ade7750f836ef3ee36eea250cc467d45c256895573ac08cc6f1", size = 3282307, upload-time = "2026-06-09T22:30:53.162Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/ff/371ea7d252656ee1eb6d83eeeef3d1d0c6baf1d6497687d081ea03814670/cryptography-48.0.1-cp39-abi3-win_amd64.whl", hash = "sha256:9a49ca6c81417f6a5edb50375a60cccdd70fa0a91a5211829dbea74eba94d2ac", size = 3793408, upload-time = "2026-06-09T22:32:15.191Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/22/adf66990e63584a68dfb50c24f48a125c07b1699899381c8151e63ed458c/cryptography-49.0.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:966fe0e9c67490071f14c0d2b1cb2dfb3023c5ce39457343931415f08382f2db", size = 4032100, upload-time = "2026-06-12T20:02:32.143Z" },
+    { url = "https://files.pythonhosted.org/packages/09/41/3797cfaf69cae04a13ee78ebd83f0678d9c02b4779d21ce24445326f1a69/cryptography-49.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:36d1709f992593689b45bda411498d62c6e365f2ca00b84657d4dadd24de16db", size = 4692978, upload-time = "2026-06-12T20:01:21.305Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/8b/43011f7ebe515a8aa20d61f290a326cd890c2e738e16e59eaff8d9c3a412/cryptography-49.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0e959b578856a3924bc0cbb710fc12c387b9412a951389f3ca61704a9e25f325", size = 4716422, upload-time = "2026-06-12T20:01:48.566Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/91/01ce7303a4579e6d3a6abef01bd322848e9ea7a219adcabc5048b9033571/cryptography-49.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:53ecee2e23f7169b6117e99fc8a944e5e50f79e69758a83b52a00cb98ab2b2d2", size = 4700503, upload-time = "2026-06-12T20:02:47.091Z" },
+    { url = "https://files.pythonhosted.org/packages/62/99/a2c95cf8293f07491e9e27c20cc4dcd18176d944e674679adeb1d0173fd6/cryptography-49.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:2eda353d8a27bcbcaa4cbed18994a74ab4d19a2ca897db188ea269ab9b71419b", size = 5309779, upload-time = "2026-06-12T20:02:08.987Z" },
+    { url = "https://files.pythonhosted.org/packages/20/2c/0622f20ff02b2ef32558733443805dc82fd4c275be01b2d19d14676f3a1b/cryptography-49.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2afe9051da7ae7bd5905da5a949280c7d2bb75682e188f650a9d0f2756b834c6", size = 4749683, upload-time = "2026-06-12T20:02:03.335Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5b/c5246635d5fd3b64e0d45ae10e99fd32fe9676a79915ccfe5a61ba9af1a5/cryptography-49.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:0b82e28ee398a386f0807bba7884d30f25218855690f45115831bcce5d90822c", size = 4337874, upload-time = "2026-06-12T20:02:54.323Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/88/05563c7fe2e914e87d1a536d06fe83e66b4e1d95cb593e05aea375531da8/cryptography-49.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:ccac2bfebc306b862133e3bb71f3f6ee8bb525240089b2d952e4144b3a6d5da7", size = 4700283, upload-time = "2026-06-12T20:01:34.822Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/b6/d7696e4e890d6ae1469935164c9e5215c557671cb78d6e3f458ccceaa632/cryptography-49.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:d0527ce944105f257f605a827d6ebead966c752038b6e8656abb9c5edee6fc68", size = 5265844, upload-time = "2026-06-12T20:01:24.09Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/3c/f3ad17eecc1a57b0ba236dc01f90e783c51f4a2f35f64777cc4f47a184b2/cryptography-49.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:cbc77da8c523d5abd028635ba850a6966fcee2c82e2bf65a41d1d8afe0f98be9", size = 4749290, upload-time = "2026-06-12T20:01:30.848Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/01/339573cf1023163a400b0b5d16f6d507de413b9f60be6fd1b77feeaf6737/cryptography-49.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b87e65d263b3e5d3bb92a57e2a6638e2f31110fa7aa890c7b2dbba42248d0a3f", size = 4834612, upload-time = "2026-06-12T20:01:29.246Z" },
+    { url = "https://files.pythonhosted.org/packages/71/fd/577302e213a1be9468f92d1afef66fcf1ef83d516819d9992ca547f592bd/cryptography-49.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:66ec79c3904820572d7e987abdf304281f141d37ad9a489b8e97066e7b9b6459", size = 4980804, upload-time = "2026-06-12T20:01:42.853Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/09/f42b1d190c5ba75f72062a387f8030d1d75f6ab035788f1d9c4b01de6525/cryptography-49.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:e5dfc1e64de5677cec922ffa8da89c546d0415bf6efdf081842e5d44c84e1f0e", size = 3810026, upload-time = "2026-06-12T20:02:39.262Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/9e/db72b3ae7fc9cfad53e630e56c6ae83b9b6ff0bf3718ffb8012d20b3aabf/cryptography-49.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:73a205dce83953d131a4aa1e0fd917a2fd1c5b1eef251e9d7152efefcbf5caf7", size = 4013892, upload-time = "2026-06-12T20:02:10.735Z" },
+    { url = "https://files.pythonhosted.org/packages/86/12/c48a424f38db03027be9f7ed5c7dc5de9933dbee992865f98b13727a009d/cryptography-49.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:196ecd6a36e4e9aa10270393bb98d8df88fccee0bf1e5128b91ae4eb4375896d", size = 4678835, upload-time = "2026-06-12T20:02:48.743Z" },
+    { url = "https://files.pythonhosted.org/packages/68/28/8a3ad4653662c93fc44dc4e5d8fd374c25c42e07b34bbfbadf49cf57a5a8/cryptography-49.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7abcee80084cda3f7691f3eb1ce480d8df49cec637b429aa35986c1de71738aa", size = 4697239, upload-time = "2026-06-12T20:02:56.03Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/b2/2193fc74f81aee4f9b62733133b73b5176718932ed8f2e4b03fa040480a6/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:4ae387c9cb68ea569ca17e490d66d8142b81c3cc814bf179974b7d146e490bbb", size = 4685593, upload-time = "2026-06-12T20:02:50.666Z" },
+    { url = "https://files.pythonhosted.org/packages/47/f1/1d3eaa243bfc5de4a187b22aa8c048b3e4980bfbe830ac46e6bac2e66947/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:f37d847238971164fdbc68ade6f6574aecc9c0af714190e2083429ff68f4ce9d", size = 5289961, upload-time = "2026-06-12T20:01:46.468Z" },
+    { url = "https://files.pythonhosted.org/packages/58/39/2d51306721330c486495853eda1c567880ff036de15a14c4b74f399934af/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:c2bc30226390d60ea19d9f82b19db005fe0452154a23c1c410c12ea801e43561", size = 4731145, upload-time = "2026-06-12T20:02:16.832Z" },
+    { url = "https://files.pythonhosted.org/packages/17/50/983e838c7fd0d87fd8c969bcdd328edaf5f756e38df5281637424c155873/cryptography-49.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:07cab27cc7b7e0fd28e5e26bb9eeedde5c135c868b46de4a27845abe94af6122", size = 4321719, upload-time = "2026-06-12T20:02:52.611Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/f5/8f571d7e27c55bce9f76f026143bcb1e040a4233149ecca0bea5fa5dd5f7/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:b20133d204d2bb56ba047642199603876c872026ca53e79c35b83772ab2cc505", size = 4685209, upload-time = "2026-06-12T20:02:07.282Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/84/0e27016a6fc5a0886f797018b26aa42f40c09a82332bff77822a451deaaa/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:b970c6da94d5bb18629db453d14f2a1300f6bf59b61e9b82377931ef95504866", size = 5246285, upload-time = "2026-06-12T20:01:32.439Z" },
+    { url = "https://files.pythonhosted.org/packages/11/2d/5e1fb307cb5931881516b464c98774b3f2c36b5d4bb9a2830253cf553cad/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d8ecde755e2e91bf773fc94e8c9d730cd7f2007004cb492263a794ec3899a1c8", size = 4730441, upload-time = "2026-06-12T20:02:01.469Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/c0/bff5a02ee731d207d6a1ed51732549d8c53d2bc8da1d10ec6f2844201d68/cryptography-49.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e3fb64c420688e5319ae25113a354015abbd8dffbfbc41781a1ea66fc7622ac3", size = 4815869, upload-time = "2026-06-12T20:01:36.574Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/26/814681d14248d95d73d5c3eea0c39a94eb8302df966f670a2c60de90974b/cryptography-49.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32703d93296f5c1f4b53349ad3a250c2cae0fdecd3a3dd5d47e616d8d616af27", size = 4960948, upload-time = "2026-06-12T20:02:18.688Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/fe/93ecac273d3738939d023612ad12cca9a3740a5345d69fda04134c43fd96/cryptography-49.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:33cd0565932807baddb67b96dbee92f2c374b5c89dee09fd74079aeb8c8dba61", size = 3799153, upload-time = "2026-06-12T20:01:39.059Z" },
+    { url = "https://files.pythonhosted.org/packages/19/2a/5bb823f5bedcf80718cea7fbc95ec5515cca3769633c4b01a32be7f30e7c/cryptography-49.0.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ec5e529fb80935c94fe7b729f9972b50e351a0e6b50aa294fd5cabb109fcc29a", size = 4025947, upload-time = "2026-06-12T20:01:25.745Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/df/40577043ca124e17012f408ddddaeb213b856336ac82ddb3bc915f39e29f/cryptography-49.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f78ff2c9ed8dc2d036b0f4d640e22522213d047c1b14e61205a7e55c80a494d4", size = 4692429, upload-time = "2026-06-12T20:01:53.628Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/99/2d13299eb3dd27b02dcfaafcc91d6b5cb3329f7cbd6d8f51921acd566c1a/cryptography-49.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:35b151772baff2c74cba7fa290ceaff4c3b11c0c881eb93eb5dbc05a7cfbba18", size = 4700968, upload-time = "2026-06-12T20:02:45.383Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/4d/9c0cd02f95e2602dd5e563da149ee0830abef3537be8b34dc56281ebe27a/cryptography-49.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:0f21641cf4b30fca7aee061ced0ec7ad7b073518088b7c9969a297c0ae796c69", size = 4697758, upload-time = "2026-06-12T20:01:41.13Z" },
+    { url = "https://files.pythonhosted.org/packages/24/01/186c825898477d77e2324d5360fefe622ff1d8d1963ec0554e2cada8ec77/cryptography-49.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9e82dcc8e56052715fb18b2429e3bca4823b1629136a2084fc45a9a5cecb9b64", size = 5298863, upload-time = "2026-06-12T20:02:24.579Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/7b/62cbbab75d0659865bf0273790031544a0b16c8072d258f9428dcd8190dc/cryptography-49.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:6f2debedf9ca60cf1d5bd466475638af5130f89965605cd818484d19987d3a21", size = 4735983, upload-time = "2026-06-12T20:01:50.14Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/72/3e798c064bc39e471008075d0f9bc9daf77a80879c092e4a8e170c585ed4/cryptography-49.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:8c25ceb16df5b9435f3f6a9829204985b0e0cbee3b48aacd432c7d2c850b44d9", size = 4334173, upload-time = "2026-06-12T20:01:44.743Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/ee/6fca21d1ac73e06f8bef71940abfd4d2f6472b4bca284d770f32bd4086f6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:28d8b15e6275f12c8a207dc309dfa957903c927d08d0cc937ee3f63f200693cc", size = 4697298, upload-time = "2026-06-12T20:02:20.918Z" },
+    { url = "https://files.pythonhosted.org/packages/67/d0/a5fcd3515f0bae49a7b6d0413cc1bdccdcc1fc0047037a0d480642cdc5d6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:6fc361c34fb6aac015ce19435876635e5c6d21db31998b0920f675f131e043b8", size = 5254338, upload-time = "2026-06-12T20:02:22.737Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/84/84fe36f19caf857d61cb7fc9c63035a47ffabd84ea12d1d393148efa3615/cryptography-49.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:2400ef9c9e2299a25614eb1dea3db54a69b1349efd043bfac9c67630d136df36", size = 4735650, upload-time = "2026-06-12T20:02:41.389Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/a0/db537264e234f7273a73ec020873d6d6b39dfd8a53db78b550ca8320440e/cryptography-49.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:67e1d20ad9ef3a563c59ef22e7a8a0b8210bd26604369ea4a30a7c66aefe504e", size = 4834820, upload-time = "2026-06-12T20:01:51.847Z" },
+    { url = "https://files.pythonhosted.org/packages/93/77/8df9eb486495979bccecd1062e2eaf435250e84437040295b57d09048b0b/cryptography-49.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:42b0684e0e40cf26122427802486f6d93aea593612603a94fbf260c7eb1e9c1b", size = 4967968, upload-time = "2026-06-12T20:02:12.524Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/e6/f60198ea8d9dfa15fff9ed4ca02ce362f6eadd9ba757dcc50634c4257b63/cryptography-49.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:026ac7423e6fa66872d3bf889be5974507da3944f866f704fa200eadacd00001", size = 3785547, upload-time = "2026-06-12T20:02:26.847Z" },
 ]
 
 [[package]]
@@ -587,7 +584,7 @@ wheels = [
 
 [[package]]
 name = "fastapi"
-version = "0.136.3"
+version = "0.137.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -596,18 +593,18 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/81/2d/ff8d91d7b564d464629a0fd50a4489c97fcb836ac230bf3a7269232a9b1f/fastapi-0.136.3.tar.gz", hash = "sha256:e487fae93ad408e6f47641ee4dfe389864fd7bec92e547ea8498fc13f43e83ab", size = 396410, upload-time = "2026-05-23T18:53:15.192Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d5/b1/e5b92c59d2c37817e77c1a8c2fc1f79cdcc04c68253e5406b43e3204cba7/fastapi-0.137.1.tar.gz", hash = "sha256:822360704230d9533d8d9475399613525968aa2f0b5bd2a3ccc9f18c88fd541c", size = 408293, upload-time = "2026-06-15T11:28:20.79Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e0/82/45359b62a067409bd929ae8a56b8ed13e5a8c8a61194b3c236920999ab83/fastapi-0.136.3-py3-none-any.whl", hash = "sha256:3d2a69bdf04b7e9f3afa292c3bc7a98816bbfafa10bc9b45f3f3700d2f761620", size = 117481, upload-time = "2026-05-23T18:53:16.924Z" },
+    { url = "https://files.pythonhosted.org/packages/da/35/380b9a5922f4340e51c309cde09e5bd32e62f02302971bee30dc15aa0624/fastapi-0.137.1-py3-none-any.whl", hash = "sha256:64f6983c59e45c4b9fdc44e57cb8035c2451ee91ea8e8ec042aca37de7cf6b69", size = 121877, upload-time = "2026-06-15T11:28:19.523Z" },
 ]
 
 [[package]]
 name = "filelock"
-version = "3.29.3"
+version = "3.29.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/91/f5/3557bf28e0f1943e4849154c821533706e6dea010f96fb6aa0b6949037d1/filelock-3.29.3.tar.gz", hash = "sha256:7fc1b3f39cf172fd8203812043c57b8a65aef9969f38b6704f628b881f761a84", size = 61956, upload-time = "2026-06-10T17:37:11.832Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e6/dc/be6cbe99670cd6e4ad387123647cb08e0c32975e223f82551e914c5568a6/filelock-3.29.4.tar.gz", hash = "sha256:10cdb3656fc44541cdf30652a93fb10ec6b05325620eb316bd26893e4201538a", size = 63028, upload-time = "2026-06-13T16:12:00.744Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/8f/b61d427c4f49a8bdadc93f4e7e74df8a6df6f77ee6e26bf0df53d3925363/filelock-3.29.3-py3-none-any.whl", hash = "sha256:e58333029cc9b925f39aad59b1d8f0a1ad836af4e60d7217f4a4dba87461261d", size = 42324, upload-time = "2026-06-10T17:37:10.37Z" },
+    { url = "https://files.pythonhosted.org/packages/13/37/a065dc3bd6e49423a6532c642ca7378d3f467b1ef44c2800c937af7f9739/filelock-3.29.4-py3-none-any.whl", hash = "sha256:dac1648087d5115554850d113e7dd8c83ab2d38e3435dde2d4f163847e57b767", size = 42757, upload-time = "2026-06-13T16:11:59.582Z" },
 ]
 
 [[package]]
@@ -1589,11 +1586,11 @@ wheels = [
 
 [[package]]
 name = "pyotp"
-version = "2.9.0"
+version = "2.10.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f3/b2/1d5994ba2acde054a443bd5e2d384175449c7d2b6d1a0614dbca3a63abfc/pyotp-2.9.0.tar.gz", hash = "sha256:346b6642e0dbdde3b4ff5a930b664ca82abfa116356ed48cc42c7d6590d36f63", size = 17763, upload-time = "2023-07-27T23:41:03.295Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/c6/c5d96a86fd0bf6fa1bbb5c5c341ff3208638b692727a683c8289068d9a11/pyotp-2.10.0.tar.gz", hash = "sha256:d01e9703443616b03c57c700b5cbffd56a1f929c1b0f8f03131bc78c1fca9d3f", size = 18625, upload-time = "2026-06-14T03:48:49.221Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c3/c0/c33c8792c3e50193ef55adb95c1c3c2786fe281123291c2dbf0eaab95a6f/pyotp-2.9.0-py3-none-any.whl", hash = "sha256:81c2e5865b8ac55e825b0358e496e1d9387c811e85bb40e71a3b29b288963612", size = 13376, upload-time = "2023-07-27T23:41:01.685Z" },
+    { url = "https://files.pythonhosted.org/packages/65/33/7b83bde70eddaaaaef487751a9c3a5cc0c0be54620ded0e120ebdc401ff9/pyotp-2.10.0-py3-none-any.whl", hash = "sha256:1df2f6a1bcc3bb0716172a5215ddc2f8c7c7fd26a13df9927d52e1746934836c", size = 13768, upload-time = "2026-06-14T03:48:47.831Z" },
 ]
 
 [[package]]
@@ -1634,7 +1631,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.0.3"
+version = "9.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -1643,9 +1640,9 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/84/0e/b5858858d74958632c49b72cb25a3976ff9f632397626715be71c89d3971/pytest-9.1.0.tar.gz", hash = "sha256:41dd9148c08072446394cefd3d79701701335a9f4cae69ba92e39f6c7f5c061c", size = 1634181, upload-time = "2026-06-13T18:52:45.983Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/5a/ba30a81239b909821b3153e303e7def45178bf353da4f72380e6c5e8793b/pytest-9.1.0-py3-none-any.whl", hash = "sha256:8ebb0e7888bdf2bdfc602ec51f8f62d50200af37356c74e503c79a94f5c81f32", size = 386453, upload-time = "2026-06-13T18:52:44.045Z" },
 ]
 
 [[package]]
@@ -1707,7 +1704,7 @@ wheels = [
 
 [[package]]
 name = "pytmbot"
-version = "0.3.3"
+version = "0.4.0.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -1763,7 +1760,7 @@ requires-dist = [
     { name = "click", marker = "extra == 'click'", specifier = ">=8.4.1" },
     { name = "docker", specifier = ">=7.1.0" },
     { name = "emoji", specifier = ">=2.15.0" },
-    { name = "fastapi", specifier = ">=0.136.3" },
+    { name = "fastapi", specifier = ">=0.137.1" },
     { name = "humanize", specifier = ">=4.15.0" },
     { name = "influxdb-client", specifier = ">=1.50.0" },
     { name = "jinja2", specifier = ">=3.1.6" },
@@ -1773,7 +1770,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.13.3" },
     { name = "pydantic-settings", specifier = ">=2.14.0" },
     { name = "pygal", specifier = ">=3.1.0" },
-    { name = "pyotp", specifier = ">=2.9.0" },
+    { name = "pyotp", specifier = ">=2.10.0" },
     { name = "pyoutlineapi", marker = "extra == 'pyoutlineapi'", specifier = ">=0.4.0" },
     { name = "pypng", specifier = ">=0.20220715.0" },
     { name = "pytelegrambotapi", specifier = ">=4.34.0" },
@@ -1789,7 +1786,7 @@ dev = [
     { name = "codeclone", extras = ["mcp"], specifier = ">=2.0.2" },
     { name = "mypy", specifier = ">=2.1.0,<3" },
     { name = "pre-commit", specifier = ">=4.6.0" },
-    { name = "pytest", specifier = ">=9.0.3,<10" },
+    { name = "pytest", specifier = ">=9.1.0,<10" },
     { name = "pytest-cov", specifier = ">=7.1.0,<8" },
     { name = "ruff", specifier = ">=0.15.17,<0.16" },
     { name = "types-cachetools", specifier = ">=7.0.0.20260503,<8" },
@@ -2229,7 +2226,7 @@ wheels = [
 
 [[package]]
 name = "virtualenv"
-version = "21.4.3"
+version = "21.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "distlib" },
@@ -2237,9 +2234,9 @@ dependencies = [
     { name = "platformdirs" },
     { name = "python-discovery" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4b/50/7564c805bb8966d9771caaba8a143fa5e57c848ce4e7fdf2d55a1feb2ead/virtualenv-21.4.3.tar.gz", hash = "sha256:938ff0fd3f4e0f0d3a025f67a3d2f25e3c3aabbcd5857ea6170619138d72d141", size = 7644454, upload-time = "2026-06-11T16:47:04.843Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/0e/933bacb37b57ae7928b0030eef205a3dbb3e37afdbdde5be2e113318958f/virtualenv-21.5.0.tar.gz", hash = "sha256:98847aadf5e2037e0e4d2e19528eb3aca6f23906422e59a510bff231a6d32fce", size = 4577424, upload-time = "2026-06-13T20:36:45.066Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a2/8d/84b0d07c6b5f685f85ddf6c87a59d3a8a895a3dfd89e759666fabe951b94/virtualenv-21.4.3-py3-none-any.whl", hash = "sha256:75f4127d4067397c64f38579ce918fec6bf9ca2cd4f48685e82952cc3c035840", size = 7625544, upload-time = "2026-06-11T16:47:01.78Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/87/b0667ede418386ab631e48924b845d326f366d61e6bd08fe68a748fae4d4/virtualenv-21.5.0-py3-none-any.whl", hash = "sha256:8f7c38605023688c89789f566959006af6d61c99eeeb9e58342eb780c5761e5e", size = 4557937, upload-time = "2026-06-13T20:36:42.967Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Release `0.4.0` for the supported `0.4` stable line.

- **Fixed** persistent reply keyboards disappearing on Telegram iOS during normal navigation.
- **Refactored** outbound Telegram messaging through `send_bot_message()` / `send_*_message()` helpers so text-only replies, plugin screens, auth flows, and post-delete navigation consistently restore the active section keyboard.
- **Security:** bumped `pydantic-settings` to `>=2.14.2` and refreshed transitive dependencies in `uv.lock` to address symlink traversal in `NestedSecretsSettingsSource` (Dependabot #95).
- **Docs:** pointed user-facing links to `https://orenlab.github.io/pytmbot/` instead of repository `docs/*.md` paths.
- **Release:** bumped project version to `0.4.0`, added `config_version: 0.4.0`, updated `SECURITY.md`, Docker tag metadata, weekly rebuild line (`0.4`), and release-facing documentation.

## Upgrade notes

- Set `config_version: "0.4.0"` to match the running app version (auto-migration handles mismatches on startup).
- Pin Docker to `orenlab/pytmbot:0.4.0` for exact reproducibility; use `0.4` / `stable` for the floating stable line.
- The `0.3.x` line is end-of-life as of this release.

## Test plan

- [x] `uv run pytest`
- [x] `uv run pre-commit run --all-files`
- [x] `uv run zensical build --strict`